### PR TITLE
Let GenericLiquid.isLiquid() return true.

### DIFF
--- a/src/main/java/org/spout/vanilla/block/GenericLiquid.java
+++ b/src/main/java/org/spout/vanilla/block/GenericLiquid.java
@@ -36,7 +36,13 @@ public class GenericLiquid extends GenericBlockMaterial implements Liquid {
 		this.flowing = flowing;
 	}
 
+	@Override
 	public boolean isFlowing() {
 		return flowing;
+	}
+	
+	@Override
+	public boolean isLiquid() {
+		return true;
 	}
 }


### PR DESCRIPTION
GenericLiquid is now a liquid according to GenericLiquid.isLiquid() .Liquid blocks can be replaced by solids.
