### PR TITLE
Fix duplicate 'SURVIVAL' text

### DIFF
--- a/src/main/java/org/spout/vanilla/command/AdministrationCommands.java
+++ b/src/main/java/org/spout/vanilla/command/AdministrationCommands.java
@@ -90,7 +90,7 @@ public class AdministrationCommands {
 							player.sendMessage("Your gamemode has been switched to SURVIVAL."); 
 							break; // TODO: Switch player to survival
 						case 2: 
-							source.sendMessage(player.getName() + "'s gamemode has been switched to SURVIVAL.");
+							source.sendMessage(player.getName() + "'s gamemode has been switched to CREATIVE.");
 							player.sendMessage("Your gamemode has been switched to CREATIVE."); 
 							break; // TODO: Switch player to creative
 						default: 


### PR DESCRIPTION
That text should've been "CREATIVE" not "SURVIVAL".

Not that it matters, since I suspect this code will probably end up rewritten to do something. ;)
