### PR TITLE
Fixed bug with material data not being sent when needed.

### DIFF
--- a/src/main/java/org/spout/vanilla/protocol/VanillaNetworkSynchronizer.java
+++ b/src/main/java/org/spout/vanilla/protocol/VanillaNetworkSynchronizer.java
@@ -46,6 +46,7 @@ import org.spout.vanilla.VanillaMessageHandlerUtils;
 import org.spout.vanilla.VanillaPlugin;
 import org.spout.vanilla.entity.living.player.SurvivalPlayer;
 import org.spout.vanilla.generator.VanillaBiomeType;
+import org.spout.vanilla.material.Tool;
 import org.spout.vanilla.protocol.msg.BlockChangeMessage;
 import org.spout.vanilla.protocol.msg.CompressedChunkMessage;
 import org.spout.vanilla.protocol.msg.EntityEquipmentMessage;
@@ -350,7 +351,11 @@ public class VanillaNetworkSynchronizer extends NetworkSynchronizer {
 		if (item == null) {
 			message = new SetWindowSlotMessage(getInventoryId(inventory.getClass()), networkSlot);
 		} else {
-			message = new SetWindowSlotMessage(getInventoryId(inventory.getClass()), networkSlot, item.getMaterial().getId(), item.getAmount(), item.getDamage(), item.getAuxData());
+			if (item.getMaterial() instanceof Tool) {
+				message = new SetWindowSlotMessage(getInventoryId(inventory.getClass()), networkSlot, item.getMaterial().getId(), item.getAmount(), item.getDamage(), item.getAuxData());
+			} else {
+				message = new SetWindowSlotMessage(getInventoryId(inventory.getClass()), networkSlot, item.getMaterial().getId(), item.getAmount(), item.getMaterial().getData(), item.getAuxData());
+			}
 		}
 		queuedInventoryUpdates.put(slot, message);
 	}

--- a/src/main/java/org/spout/vanilla/protocol/codec/SetWindowSlotsCodec.java
+++ b/src/main/java/org/spout/vanilla/protocol/codec/SetWindowSlotsCodec.java
@@ -32,6 +32,7 @@ import org.spout.api.inventory.ItemStack;
 import org.spout.api.material.MaterialData;
 import org.spout.api.protocol.MessageCodec;
 import org.spout.nbt.Tag;
+import org.spout.vanilla.material.Tool;
 import org.spout.vanilla.protocol.ChannelBufferUtils;
 import org.spout.vanilla.protocol.msg.SetWindowSlotsMessage;
 
@@ -78,7 +79,13 @@ public final class SetWindowSlotsCodec extends MessageCodec<SetWindowSlotsMessag
 			} else {
 				buffer.writeShort(item.getMaterial().getId());
 				buffer.writeByte(item.getAmount());
-				buffer.writeShort(item.getDamage());
+				if (item.getMaterial() instanceof Tool) {
+					System.out.println("damage");
+					buffer.writeShort(item.getDamage());
+				} else {
+					System.out.println("data");
+					buffer.writeShort(item.getMaterial().getData());
+				}
 				if (ChannelBufferUtils.hasNbtData(item.getMaterial().getData())) {
 					ChannelBufferUtils.writeCompound(buffer, item.getAuxData());
 				}

--- a/src/main/java/org/spout/vanilla/protocol/entity/object/PickupEntityProtocol.java
+++ b/src/main/java/org/spout/vanilla/protocol/entity/object/PickupEntityProtocol.java
@@ -30,6 +30,7 @@ import org.spout.api.entity.Entity;
 import org.spout.api.protocol.EntityProtocol;
 import org.spout.api.protocol.Message;
 import org.spout.vanilla.entity.object.Item;
+import org.spout.vanilla.material.Tool;
 import org.spout.vanilla.protocol.VanillaEntityProtocol;
 import org.spout.vanilla.protocol.msg.SpawnItemMessage;
 
@@ -48,7 +49,11 @@ public class PickupEntityProtocol extends VanillaEntityProtocol implements Entit
 		int p = (int) (entity.getPitch() * 32);
 		if (c instanceof Item) {
 			Item pi = (Item) c;
-			return new SpawnItemMessage(id, (int) pi.getMaterial().getId(), pi.getAmount(), pi.getDamage(), x, y, z, r, p, pi.getRoll());
+			if (c instanceof Tool) {
+				return new SpawnItemMessage(id, (int) pi.getMaterial().getId(), pi.getAmount(), pi.getDamage(), x, y, z, r, p, pi.getRoll());
+			} else {
+				return new SpawnItemMessage(id, (int) pi.getMaterial().getId(), pi.getAmount(), pi.getMaterial().getData(), x, y, z, r, p, pi.getRoll());
+			}
 		}
 
 		return null;


### PR DESCRIPTION
Some items (pickaxes, shovels, ...) use `ItemStack.getDamage()` for durability, while others (wool, spawn eggs, ...) use `Material.getData()`. The protocol only lets you send one, so this makes it where it sends the damage for tools, and data for other items.

Signed-off-by: Chase W chasew@silkweaver.com
