### PR TITLE
Added track placement logic and improved block placement handling

### DIFF
--- a/src/main/java/org/spout/vanilla/material/attachable/AbstractAttachable.java
+++ b/src/main/java/org/spout/vanilla/material/attachable/AbstractAttachable.java
@@ -25,6 +25,7 @@
  */
 package org.spout.vanilla.material.attachable;
 
+import org.spout.api.Source;
 import org.spout.api.geo.World;
 import org.spout.api.geo.cuboid.Block;
 import org.spout.api.material.block.BlockFace;
@@ -59,4 +60,10 @@ public abstract class AbstractAttachable extends GenericBlock implements Attacha
 		Vector3 offset = base.getOffset();
 		return world.getBlock((int) (x + offset.getX()), (int) (y + offset.getY()), (int) (z + offset.getZ()));
 	}
+	
+	@Override
+	public boolean onPlacement(World world, int x, int y, int z, short data, BlockFace against, Source source) {
+		return super.onPlacement(world, x, y, z, this.getDataForFace(against.getOpposite()), against, source);
+	}
+	
 }

--- a/src/main/java/org/spout/vanilla/material/block/MinecartTrack.java
+++ b/src/main/java/org/spout/vanilla/material/block/MinecartTrack.java
@@ -26,23 +26,28 @@
 package org.spout.vanilla.material.block;
 
 import org.spout.api.geo.World;
-import org.spout.vanilla.material.attachable.GroundAttachable;
-import org.spout.vanilla.util.MinecartTrackLogic;
+import org.spout.vanilla.material.block.data.Rails;
 
-public class MinecartTrack extends GroundAttachable {
+public class MinecartTrack extends MinecartTrackBase implements RedstoneTarget {
+	
 	public MinecartTrack(String name, int id) {
 		super(name, id);
 	}
 
+	@Override
 	public boolean canCurve() {
 		return true;
 	}
-
+	
 	@Override
-	public void onUpdate(World world, int x, int y, int z) {
-		MinecartTrackLogic logic = MinecartTrackLogic.create(world, x, y, z);
-		if (logic != null) {
-			logic.refresh();
-		}
+	public Rails createData(short data) {
+		return new Rails(data);
 	}
+	
+	@Override
+	public boolean providesAttachPoint(World world, int x, int y, int z, int tx, int ty, int tz) {
+		// TODO Auto-generated method stub
+		return false;
+	}
+	
 }

--- a/src/main/java/org/spout/vanilla/material/block/MinecartTrackBase.java
+++ b/src/main/java/org/spout/vanilla/material/block/MinecartTrackBase.java
@@ -25,40 +25,35 @@
  */
 package org.spout.vanilla.material.block;
 
+import org.spout.api.Source;
 import org.spout.api.geo.World;
-import org.spout.vanilla.material.block.data.DetectorRails;
+import org.spout.api.material.block.BlockFace;
+import org.spout.vanilla.material.attachable.GroundAttachable;
+import org.spout.vanilla.util.MinecartTrackLogic;
 
-public class MinecartTrackDetector extends MinecartTrackBase implements RedstoneSource {
-	public MinecartTrackDetector(String name, int id) {
+public abstract class MinecartTrackBase extends GroundAttachable {
+	
+	public MinecartTrackBase(String name, int id) {
 		super(name, id);
 	}
-
-	@Override
-	public boolean canCurve() {
-		return false;
-	}
-
-	@Override
-	public short getRedstonePower(World world, int x, int y, int z, int tx, int ty, int tz) {
-		// TODO Auto-generated method stub
-		return 0;
-	}
-
-	@Override
-	public boolean providesPowerTo(World world, int x, int y, int z, int tx, int ty, int tz) {
-		// TODO Auto-generated method stub
-		return false;
-	}
-
-	@Override
-	public boolean providesAttachPoint(World world, int x, int y, int z, int tx, int ty, int tz) {
-		// TODO Auto-generated method stub
-		return false;
+	
+	public abstract boolean canCurve();
+	
+	public void doTrackLogic(World world, int x, int y, int z) {
+		MinecartTrackLogic logic = MinecartTrackLogic.create(world, x, y, z);
+		if (logic != null) {
+			logic.refresh();
+		}
 	}
 	
 	@Override
-	public DetectorRails createData(short data) {
-		return new DetectorRails(data);
+	public boolean onPlacement(World world, int x, int y, int z, short data, BlockFace against, Source source) {
+		if (super.onPlacement(world, x, y, z, data, against, source)) {
+			this.doTrackLogic(world, x, y, z);
+			return true;
+		} else {
+			return false;
+		}
 	}
 	
 }

--- a/src/main/java/org/spout/vanilla/material/block/MinecartTrackPowered.java
+++ b/src/main/java/org/spout/vanilla/material/block/MinecartTrackPowered.java
@@ -26,8 +26,9 @@
 package org.spout.vanilla.material.block;
 
 import org.spout.api.geo.World;
+import org.spout.vanilla.material.block.data.PoweredRails;
 
-public class MinecartTrackPowered extends MinecartTrack implements RedstoneTarget {
+public class MinecartTrackPowered extends MinecartTrackBase implements RedstoneTarget {
 	public MinecartTrackPowered(String name, int id) {
 		super(name, id);
 	}
@@ -42,4 +43,10 @@ public class MinecartTrackPowered extends MinecartTrack implements RedstoneTarge
 		// TODO Auto-generated method stub
 		return false;
 	}
+	
+	@Override
+	public PoweredRails createData(short data) {
+		return new PoweredRails(data);
+	}
+
 }

--- a/src/main/java/org/spout/vanilla/material/block/data/DetectorRails.java
+++ b/src/main/java/org/spout/vanilla/material/block/data/DetectorRails.java
@@ -23,42 +23,45 @@
  * License and see <http://www.spout.org/SpoutDevLicenseV1.txt> for the full license,
  * including the MIT license.
  */
-package org.spout.vanilla.material.block;
+package org.spout.vanilla.material.block.data;
 
-import org.spout.api.geo.World;
-import org.spout.vanilla.material.block.data.DetectorRails;
+import org.spout.api.material.BlockMaterial;
+import org.spout.vanilla.VanillaMaterials;
+import org.spout.vanilla.util.RailsState;
 
-public class MinecartTrackDetector extends MinecartTrackBase implements RedstoneSource {
-	public MinecartTrackDetector(String name, int id) {
-		super(name, id);
+public class DetectorRails extends Rails {
+	
+	private boolean pressed;
+	public DetectorRails(short data) {
+		super((short) (data & 0x7));
+		this.pressed = (data & 0x8) == 0x8;
 	}
-
-	@Override
-	public boolean canCurve() {
-		return false;
+	
+	public DetectorRails(RailsState state, boolean pressed) {
+		super(state);
+		this.pressed = pressed;
 	}
-
-	@Override
-	public short getRedstonePower(World world, int x, int y, int z, int tx, int ty, int tz) {
-		// TODO Auto-generated method stub
-		return 0;
+	
+	public boolean isPressed() {
+		return this.pressed;
 	}
-
-	@Override
-	public boolean providesPowerTo(World world, int x, int y, int z, int tx, int ty, int tz) {
-		// TODO Auto-generated method stub
-		return false;
-	}
-
-	@Override
-	public boolean providesAttachPoint(World world, int x, int y, int z, int tx, int ty, int tz) {
-		// TODO Auto-generated method stub
-		return false;
+	
+	public void setPressed(boolean pressed) {
+		this.pressed = pressed;
 	}
 	
 	@Override
-	public DetectorRails createData(short data) {
-		return new DetectorRails(data);
+	public short getData() {
+		short data = super.getData();
+		if (this.pressed) {
+			data |= 0x8;
+		}
+		return data;
 	}
 	
+	@Override
+	public BlockMaterial getMaterial() {
+		return VanillaMaterials.DETECTOR_RAIL;
+	}
+
 }

--- a/src/main/java/org/spout/vanilla/material/block/data/MaterialData.java
+++ b/src/main/java/org/spout/vanilla/material/block/data/MaterialData.java
@@ -23,42 +23,17 @@
  * License and see <http://www.spout.org/SpoutDevLicenseV1.txt> for the full license,
  * including the MIT license.
  */
-package org.spout.vanilla.material.block;
+package org.spout.vanilla.material.block.data;
 
-import org.spout.api.geo.World;
-import org.spout.vanilla.material.block.data.DetectorRails;
+import org.spout.api.material.BlockMaterial;
 
-public class MinecartTrackDetector extends MinecartTrackBase implements RedstoneSource {
-	public MinecartTrackDetector(String name, int id) {
-		super(name, id);
-	}
-
-	@Override
-	public boolean canCurve() {
-		return false;
-	}
-
-	@Override
-	public short getRedstonePower(World world, int x, int y, int z, int tx, int ty, int tz) {
-		// TODO Auto-generated method stub
-		return 0;
-	}
-
-	@Override
-	public boolean providesPowerTo(World world, int x, int y, int z, int tx, int ty, int tz) {
-		// TODO Auto-generated method stub
-		return false;
-	}
-
-	@Override
-	public boolean providesAttachPoint(World world, int x, int y, int z, int tx, int ty, int tz) {
-		// TODO Auto-generated method stub
-		return false;
-	}
+//FIXME: Needs to be placed in SpoutAPI instead
+public interface MaterialData {
 	
-	@Override
-	public DetectorRails createData(short data) {
-		return new DetectorRails(data);
-	}
+	public void setData(short data);
 	
+	public short getData();
+	
+	public BlockMaterial getMaterial();
+
 }

--- a/src/main/java/org/spout/vanilla/material/block/data/PoweredRails.java
+++ b/src/main/java/org/spout/vanilla/material/block/data/PoweredRails.java
@@ -23,42 +23,46 @@
  * License and see <http://www.spout.org/SpoutDevLicenseV1.txt> for the full license,
  * including the MIT license.
  */
-package org.spout.vanilla.material.block;
+package org.spout.vanilla.material.block.data;
 
-import org.spout.api.geo.World;
-import org.spout.vanilla.material.block.data.DetectorRails;
+import org.spout.api.material.BlockMaterial;
+import org.spout.vanilla.VanillaMaterials;
+import org.spout.vanilla.util.RailsState;
 
-public class MinecartTrackDetector extends MinecartTrackBase implements RedstoneSource {
-	public MinecartTrackDetector(String name, int id) {
-		super(name, id);
+public class PoweredRails extends Rails {
+	
+	private boolean powered;
+	
+	public PoweredRails(short data) {
+		super((short) (data & 0x7));
+		this.powered = (data & 0x8) == 0x8;
 	}
-
-	@Override
-	public boolean canCurve() {
-		return false;
+	
+	public PoweredRails(RailsState state, boolean powered) {
+		super(state);
+		this.powered = powered;
 	}
-
-	@Override
-	public short getRedstonePower(World world, int x, int y, int z, int tx, int ty, int tz) {
-		// TODO Auto-generated method stub
-		return 0;
+	
+	public boolean isPowered() {
+		return this.powered;
 	}
-
-	@Override
-	public boolean providesPowerTo(World world, int x, int y, int z, int tx, int ty, int tz) {
-		// TODO Auto-generated method stub
-		return false;
-	}
-
-	@Override
-	public boolean providesAttachPoint(World world, int x, int y, int z, int tx, int ty, int tz) {
-		// TODO Auto-generated method stub
-		return false;
+	
+	public void setPowered(boolean pressed) {
+		this.powered = pressed;
 	}
 	
 	@Override
-	public DetectorRails createData(short data) {
-		return new DetectorRails(data);
+	public short getData() {
+		short data = super.getData();
+		if (this.powered) {
+			data |= 0x8;
+		}
+		return data;
 	}
 	
+	@Override
+	public BlockMaterial getMaterial() {
+		return VanillaMaterials.POWERED_RAIL;
+	}
+
 }

--- a/src/main/java/org/spout/vanilla/material/block/data/Rails.java
+++ b/src/main/java/org/spout/vanilla/material/block/data/Rails.java
@@ -1,0 +1,117 @@
+/*
+ * This file is part of Vanilla (http://www.spout.org/).
+ *
+ * Vanilla is licensed under the SpoutDev License Version 1.
+ *
+ * Vanilla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In addition, 180 days after any changes are published, you can use the
+ * software, incorporating those changes, under the terms of the MIT license,
+ * as described in the SpoutDev License Version 1.
+ *
+ * Vanilla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License,
+ * the MIT license and the SpoutDev License Version 1 along with this program.
+ * If not, see <http://www.gnu.org/licenses/> for the GNU Lesser General Public
+ * License and see <http://www.spout.org/SpoutDevLicenseV1.txt> for the full license,
+ * including the MIT license.
+ */
+package org.spout.vanilla.material.block.data;
+
+import org.spout.api.material.BlockMaterial;
+import org.spout.api.material.block.BlockFace;
+import org.spout.vanilla.VanillaMaterials;
+import org.spout.vanilla.util.RailsState;
+
+public class Rails implements MaterialData {
+			
+	private RailsState state;
+	
+	public Rails(short data) {
+		this.setData(data);
+	}
+	
+	public Rails(RailsState state) {
+		this.setState(state);
+	}
+
+	public boolean canCurve() {
+		return true;
+	}
+		
+	public boolean isSloped() {
+		return this.state.isSloped();
+	}
+	
+	public boolean isCurved() {
+		return this.state.isCurved();
+	}
+	
+	public boolean isConnected(BlockFace face) {
+		return this.state.isConnected(face);
+	}
+	
+	public RailsState getState() {
+		return this.state;
+	}
+	
+	public BlockFace[] getDirections() {
+		return this.state.getDirections();
+	}
+	
+	public void setDirection(BlockFace direction) {
+		this.setDirection(direction, false);
+	}
+	
+	public void setDirection(BlockFace direction, boolean sloped) {
+		this.setState(RailsState.get(direction, sloped));
+	}
+		
+	public void setDirection(BlockFace from, BlockFace to) {
+		this.setState(RailsState.get(from, to));
+	}
+	
+	/**
+	 * Sets the direction in such a way that both directions are connected
+	 * @param dir1
+	 * @param dir2
+	 * @return true if the operation succeeded
+	 */
+	public void setState(RailsState state) {
+		if (state == null) {
+			throw new IllegalArgumentException("Rails state can't be null!");
+		} else if (!this.canCurve() && state.isCurved()) {
+			throw new IllegalArgumentException("This type of rails can't curve!");
+		} else {
+			this.state = state;
+		}
+	}
+	
+	@Override
+	public void setData(short data) {
+		RailsState state = RailsState.get(data);
+		if (state == null) {
+			throw new IllegalArgumentException("Invalid rails material data: " + data);
+		} else {
+			this.setState(state);
+		}
+	}
+	
+	@Override
+	public short getData() {
+		return this.state.getData();
+	}
+
+	@Override
+	public BlockMaterial getMaterial() {
+		return VanillaMaterials.RAILS;
+	}
+	
+}

--- a/src/main/java/org/spout/vanilla/material/block/data/SimpleMaterialData.java
+++ b/src/main/java/org/spout/vanilla/material/block/data/SimpleMaterialData.java
@@ -23,42 +23,32 @@
  * License and see <http://www.spout.org/SpoutDevLicenseV1.txt> for the full license,
  * including the MIT license.
  */
-package org.spout.vanilla.material.block;
+package org.spout.vanilla.material.block.data;
 
-import org.spout.api.geo.World;
-import org.spout.vanilla.material.block.data.DetectorRails;
+import org.spout.api.material.BlockMaterial;
 
-public class MinecartTrackDetector extends MinecartTrackBase implements RedstoneSource {
-	public MinecartTrackDetector(String name, int id) {
-		super(name, id);
-	}
+public class SimpleMaterialData implements MaterialData {
 
-	@Override
-	public boolean canCurve() {
-		return false;
-	}
-
-	@Override
-	public short getRedstonePower(World world, int x, int y, int z, int tx, int ty, int tz) {
-		// TODO Auto-generated method stub
-		return 0;
-	}
-
-	@Override
-	public boolean providesPowerTo(World world, int x, int y, int z, int tx, int ty, int tz) {
-		// TODO Auto-generated method stub
-		return false;
-	}
-
-	@Override
-	public boolean providesAttachPoint(World world, int x, int y, int z, int tx, int ty, int tz) {
-		// TODO Auto-generated method stub
-		return false;
+	private short data;
+	private final BlockMaterial material;
+	public SimpleMaterialData(BlockMaterial material, short data) {
+		this.data = data;
+		this.material = material;
 	}
 	
 	@Override
-	public DetectorRails createData(short data) {
-		return new DetectorRails(data);
+	public void setData(short data) {
+		this.data = data;
+	}
+
+	@Override
+	public short getData() {
+		return this.data;
 	}
 	
+	@Override
+	public BlockMaterial getMaterial() {
+		return this.material;
+	}
+
 }

--- a/src/main/java/org/spout/vanilla/material/generic/GenericBlock.java
+++ b/src/main/java/org/spout/vanilla/material/generic/GenericBlock.java
@@ -31,10 +31,13 @@ import org.spout.api.material.GenericBlockMaterial;
 import org.spout.api.material.block.BlockFace;
 import org.spout.api.math.Vector3;
 import org.spout.vanilla.material.Block;
+import org.spout.vanilla.material.block.data.MaterialData;
+import org.spout.vanilla.material.block.data.SimpleMaterialData;
 import org.spout.vanilla.material.item.RedstoneTorch;
 import org.spout.vanilla.material.item.RedstoneWire;
 
 public class GenericBlock extends GenericBlockMaterial implements Block {
+
 	private static BlockFace indirectSourcesWire[] = {BlockFace.EAST, BlockFace.SOUTH, BlockFace.WEST, BlockFace.NORTH};
 	private float resistance;
 	private int dropId;
@@ -142,4 +145,9 @@ public class GenericBlock extends GenericBlockMaterial implements Block {
 		
 		return this;
 	}
+	
+	public MaterialData createData(short data) {
+		return new SimpleMaterialData(this, data);
+	}
+		
 }

--- a/src/main/java/org/spout/vanilla/util/MinecartTrackLogic.java
+++ b/src/main/java/org/spout/vanilla/util/MinecartTrackLogic.java
@@ -25,56 +25,75 @@
  */
 package org.spout.vanilla.util;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.spout.api.Source;
 import org.spout.api.geo.World;
 import org.spout.api.material.BlockMaterial;
 import org.spout.api.material.block.BlockFace;
 import org.spout.vanilla.material.block.MinecartTrack;
+import org.spout.vanilla.material.block.data.Rails;
+import org.spout.vanilla.material.generic.GenericBlock;
 
-public class MinecartTrackLogic {
+public class MinecartTrackLogic implements Source {
+	
 	public int x, y, z;
 	public World world;
-	public MinecartTrack material;
-	public BlockFace currentDirection;
+	public Rails data;
 	public boolean isPowered;
-
-	public MinecartTrackLogic(MinecartTrack material, World world, int x, int y, int z) {
-		this.material = material;
+	public BlockFace direction;
+	public boolean changed = false;
+	public List<MinecartTrackLogic> neighbours = new ArrayList<MinecartTrackLogic>();
+		
+	private MinecartTrackLogic(World world, int x, int y, int z, Rails data) {
 		this.world = world;
 		this.x = x;
 		this.y = y;
 		this.z = z;
-		this.isPowered = false; //TODO: find out powered state
-		this.updateDirection();
+		this.isPowered = ((GenericBlock) data.getMaterial()).getIndirectRedstonePower(world, x, y, z) > 0;
+		this.data = data;
+		this.direction = BlockFace.THIS;
 	}
-
-	public void updateDirection() {
-		//TODO: Get direction from the block data
-		//this.currentDirection = 
-	}
-
+	
 	public static MinecartTrackLogic create(World world, int x, int y, int z) {
 		BlockMaterial mat = world.getBlockMaterial(x, y, z);
 		if (mat instanceof MinecartTrack) {
-			return new MinecartTrackLogic((MinecartTrack) mat, world, x, y, z);
+			Rails rails = ((MinecartTrack) mat).createData(world.getBlockData(x, y, z));
+			return new MinecartTrackLogic(world, x, y, z, rails);
 		} else {
 			return null;
 		}
 	}
-
-	private boolean isMinecartTrack(int x, int y, int z) {
-		if (world.getBlockMaterial(x, y, z) instanceof MinecartTrack) {
-			return true;
+	
+	public MinecartTrackLogic addNeighbour(BlockFace direction, boolean genSubNeighbours) {
+		MinecartTrackLogic logic = this.getLogic(direction);
+		if (logic != null) {
+			//find out what connections this rails has
+			if (genSubNeighbours) {
+				for (BlockFace conn : logic.data.getDirections()) {
+					MinecartTrackLogic neigh = logic.addNeighbour(conn, false);
+					if (conn == direction.getOpposite() && neigh != null) {
+						neigh.data = this.data;
+					}
+				}
+				if (!logic.data.isConnected(direction.getOpposite())) {
+					if (logic.neighbours.size() >= 2) {
+						return null;
+					}
+				}
+			}
+			logic.direction = direction;
+			this.neighbours.add(logic);
 		}
-		if (world.getBlockMaterial(x, y + 1, z) instanceof MinecartTrack) {
-			return true;
-		}
-		if (world.getBlockMaterial(x, y - 1, z) instanceof MinecartTrack) {
-			return true;
-		}
-		return false;
+		return logic;
 	}
-
-	private MinecartTrackLogic getLogic(int x, int y, int z) {
+		
+	public MinecartTrackLogic getLogic(BlockFace direction) {
+		int x = this.x + (int) direction.getOffset().getX();
+		int y = this.y + (int) direction.getOffset().getY();
+		int z = this.z + (int) direction.getOffset().getZ();
 		MinecartTrackLogic logic;
 		logic = create(this.world, x, y, z);
 		if (logic != null) {
@@ -87,47 +106,125 @@ public class MinecartTrackLogic {
 		logic = create(this.world, x, y - 1, z);
 		return logic;
 	}
-
-	public boolean isConnected(MinecartTrackLogic track) {
-		//TODO: Check if this track connects to the given track
-		return false;
+	
+	public boolean setDirection(BlockFace dir1, BlockFace dir2) {
+		return this.setDirection(RailsState.get(dir1, dir2));
 	}
-
-	public boolean canConnect(MinecartTrackLogic to) {
-		if (isConnected(to)) {
+	
+	public boolean setDirection(BlockFace direction, boolean sloped) {
+		return this.setDirection(RailsState.get(direction, sloped));
+	}
+	
+	public boolean setDirection(RailsState state) {
+		System.out.println("SETTING TO " + state);
+		if (state != this.data.getState()) {
+			this.data.setState(state);
+			this.changed = true;
 			return true;
 		} else {
-			//TODO: Check if a connection can be made
 			return false;
 		}
 	}
-
-	private static BlockFace toStraightTrack(BlockFace face) {
-		switch (face) {
-			case NORTH:
-			case SOUTH:
-				return BlockFace.SOUTH;
-			case EAST:
-			case WEST:
-				return BlockFace.WEST;
-			default:
-				return face;
-		}
-	}
-
-	public boolean connect(BlockFace direction) {
-		if (this.material.canCurve()) {
-			//TODO: Force this track to face to the given direction
-			//find out what other directions to look at
+	
+	public BlockFace getDirection(MinecartTrackLogic to) {
+		if (to.direction == BlockFace.THIS) {
+			return this.direction.getOpposite();
 		} else {
-			this.currentDirection = toStraightTrack(direction);
+			return to.direction;
 		}
-		//TODO: Update block data
-		return false;
 	}
-
+		
+	public String toString() {
+		return this.world.getName() + " " + this.x + "/" + this.y + "/" + this.z + " neighbours: " + this.neighbours.size();
+	}
+	
 	public void refresh() {
-		//TODO: Update this track piece based on environment
-		//check if connections are made, and if new connections need to be made
+		this.refresh(true);
 	}
+	
+	private void refresh(boolean isMain) {
+		//Update this track piece based on environment
+		this.neighbours.clear();
+		this.addNeighbour(BlockFace.NORTH, true);
+		this.addNeighbour(BlockFace.EAST, true);
+		this.addNeighbour(BlockFace.SOUTH, true);
+		this.addNeighbour(BlockFace.WEST, true);
+		if (this.neighbours.size() == 3) {
+			//sort neighbours: middle at index 1
+			BlockFace middle = this.neighbours.get(1).direction.getOpposite();
+			if (middle == this.neighbours.get(2).direction) {
+				//dirs[1] need to be swapped with dirs[2]
+				Collections.swap(this.neighbours, 1, 2);
+			} else if (middle == this.neighbours.get(0).direction) {
+				//dirs[1] need to be swapped with dirs[0]
+				Collections.swap(this.neighbours, 1, 0);
+			}
+		}
+		
+		System.out.println(this.toString());
+		if (this.neighbours.size() == 1) {
+			//align tracks straight to face this direction
+			MinecartTrackLogic to = this.neighbours.get(0);
+			BlockFace direction = this.getDirection(to);
+			this.setDirection(direction, to.y > this.y);
+		} else if (this.neighbours.size() == 2) {
+			//try to make a fixed curve
+			MinecartTrackLogic r1 = this.neighbours.get(0);
+			MinecartTrackLogic r2 = this.neighbours.get(1);
+			if (r1.direction.getOpposite() == r2.direction) {
+				//straight track
+				//needs slope?
+				if (r1.y > this.y) {
+					if (this.setDirection(r1.direction, true) && isMain) {
+						r1.refresh(false);
+					}
+				} else if (r2.y > this.y) {
+					if (this.setDirection(r2.direction, true) && isMain) {
+						r2.refresh(false);
+					}
+				} else {
+					if (this.setDirection(r1.direction, false) && isMain) {
+						r1.refresh(false);
+					}
+				}
+			} else if (this.data.canCurve()) {
+				//curve
+				if (this.setDirection(r1.direction, r2.direction) && isMain) {
+					r1.refresh(false);
+					r2.refresh(false);
+				}
+			} else {
+				//face to r1 anyway
+				if (this.setDirection(r1.direction, r1.y > this.y) && isMain) {
+					r1.refresh(false);
+				}
+			}
+		} else if (this.neighbours.size() == 3) {
+			//this will ALWAYS be a curve leading to [1]
+			//pick [0] or [2]?
+			BlockFace main = this.neighbours.get(1).direction;
+			MinecartTrackLogic to;
+			if (this.isPowered) {
+				to = this.neighbours.get(0);
+			} else {
+				to = this.neighbours.get(2);
+			}
+			if (this.setDirection(main, to.direction) && isMain) {
+				to.refresh(false);
+			}
+		}
+		if (isMain) {
+			this.refreshData();
+		}
+	}
+	
+	private void refreshData() {
+		if (this.changed) {
+			this.world.setBlockData(this.x, this.y, this.z, this.data.getData(), false, this);
+		}
+		for (MinecartTrackLogic logic : this.neighbours) {
+			logic.refreshData();
+		}
+	}
+	
 }

--- a/src/main/java/org/spout/vanilla/util/RailsState.java
+++ b/src/main/java/org/spout/vanilla/util/RailsState.java
@@ -1,0 +1,109 @@
+/*
+ * This file is part of Vanilla (http://www.spout.org/).
+ *
+ * Vanilla is licensed under the SpoutDev License Version 1.
+ *
+ * Vanilla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In addition, 180 days after any changes are published, you can use the
+ * software, incorporating those changes, under the terms of the MIT license,
+ * as described in the SpoutDev License Version 1.
+ *
+ * Vanilla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License,
+ * the MIT license and the SpoutDev License Version 1 along with this program.
+ * If not, see <http://www.gnu.org/licenses/> for the GNU Lesser General Public
+ * License and see <http://www.spout.org/SpoutDevLicenseV1.txt> for the full license,
+ * including the MIT license.
+ */
+package org.spout.vanilla.util;
+
+import org.spout.api.material.block.BlockFace;
+
+/**
+ * Indicates the direction of a minecart track
+ */
+public enum RailsState {
+	
+	EAST(BlockFace.EAST, BlockFace.WEST, false),
+	SOUTH(BlockFace.SOUTH, BlockFace.NORTH, false),
+	SOUTH_SLOPED(BlockFace.SOUTH, BlockFace.NORTH, true),
+	NORTH_SLOPED(BlockFace.NORTH, BlockFace.SOUTH, true),
+	EAST_SLOPED(BlockFace.EAST, BlockFace.WEST, true),
+	WEST_SLOPED(BlockFace.WEST, BlockFace.EAST, true),
+	NORTH_WEST(BlockFace.NORTH, BlockFace.WEST, false),
+	NORTH_EAST(BlockFace.NORTH, BlockFace.EAST, false),
+	SOUTH_EAST(BlockFace.SOUTH, BlockFace.EAST, false),
+	SOUTH_WEST(BlockFace.SOUTH, BlockFace.WEST, false);
+		
+	private final BlockFace[] directions;
+	private final boolean curved;
+	private final boolean sloped;
+	
+	public boolean isCurved() {
+		return this.curved;
+	}
+	
+	public boolean isSloped() {
+		return this.sloped;
+	}
+	
+	private RailsState(BlockFace dir1, BlockFace dir2, boolean sloped) {
+		this.directions = new BlockFace[] {dir1, dir2};
+		this.curved = dir1.getOpposite() != dir2;
+		this.sloped = sloped;
+	}
+	
+	public byte getData() {
+		return (byte) this.ordinal();
+	}
+	
+	public boolean isConnected(BlockFace direction) {
+		return this.directions[0] == direction || this.directions[1] == direction;
+	}
+	
+	public BlockFace[] getDirections() {
+		return this.directions;
+	}
+	
+	public static RailsState get(int data) {
+		if (data >= values().length || data < 0) {
+			return null;
+		} else {
+			return values()[data];
+		}
+	}
+	
+	public static RailsState get(BlockFace direction, boolean sloped) {
+		for (RailsState dir : values()) {
+			if (dir.isCurved()) continue;
+			if (sloped != dir.isSloped()) continue;
+			if (sloped) {
+				if (dir.getDirections()[0] == direction) {
+					return dir;
+				}
+			} else if (dir.isConnected(direction)) {
+				return dir;
+			}
+		}
+		return null;
+	}
+	
+	public static RailsState get(BlockFace from, BlockFace to) {
+		for (RailsState dir : values()) {
+			if (dir.isSloped()) continue;
+			if (dir.isConnected(from) && dir.isConnected(to)) {
+				return dir;
+			}
+		}
+		return null;
+	}
+	
+}


### PR DESCRIPTION
Signed-off-by: berger killer bergerkiller@gmail.com

It will now 100% simulate track placement. It will automatically connect neighbouring rails and powered states are partially working. I use the onPlacement (which I added in another pull for SpoutAPI), in which all possible block materials can manually handle block placement, including cancelling it. I converted the placement routine in the player placement handler to use this new function. The attachable code has been shipped over in the correct class.

You can now easily add the placement routine for any block, including signs and others. :)
