### PR TITLE
Fix circular reference issues

### DIFF
--- a/src/main/java/org/spout/vanilla/VanillaMaterials.java
+++ b/src/main/java/org/spout/vanilla/VanillaMaterials.java
@@ -45,10 +45,8 @@ import org.spout.vanilla.material.block.Sapling;
 import org.spout.vanilla.material.block.Slab;
 import org.spout.vanilla.material.block.Solid;
 import org.spout.vanilla.material.block.StoneBrick;
-import org.spout.vanilla.material.block.TallGrass;
 import org.spout.vanilla.material.block.Tree;
 import org.spout.vanilla.material.block.WheatCrop;
-import org.spout.vanilla.material.block.Wool;
 import org.spout.vanilla.material.generic.GenericArmor;
 import org.spout.vanilla.material.generic.GenericBlock;
 import org.spout.vanilla.material.generic.GenericBlockItem;
@@ -60,18 +58,19 @@ import org.spout.vanilla.material.generic.GenericLiquid;
 import org.spout.vanilla.material.generic.GenericRangedWeapon;
 import org.spout.vanilla.material.generic.GenericTool;
 import org.spout.vanilla.material.generic.GenericWeapon;
-import org.spout.vanilla.material.item.Coal;
 import org.spout.vanilla.material.item.DoorBlock;
 import org.spout.vanilla.material.item.DoorItem;
-import org.spout.vanilla.material.item.Dye;
 import org.spout.vanilla.material.item.Minecart;
-import org.spout.vanilla.material.item.Potion;
 import org.spout.vanilla.material.item.PoweredMinecart;
 import org.spout.vanilla.material.item.RedstoneTorch;
 import org.spout.vanilla.material.item.RedstoneWire;
 import org.spout.vanilla.material.item.Shears;
-import org.spout.vanilla.material.item.SpawnEgg;
 import org.spout.vanilla.material.item.StorageMinecart;
+import org.spout.vanilla.material.main.CoalMain;
+import org.spout.vanilla.material.main.DyeMain;
+import org.spout.vanilla.material.main.PotionMain;
+import org.spout.vanilla.material.main.TallGrassMain;
+import org.spout.vanilla.material.main.WoolMain;
 
 public final class VanillaMaterials {
 	public static final BlockMaterial AIR = BlockMaterial.AIR;
@@ -105,11 +104,11 @@ public final class VanillaMaterials {
 	public static final BlockMaterial DETECTOR_RAIL = new MinecartTrackDetector("Detector Rail", 28).setHardness(0.7F).setResistance(1.2F);
 	public static final BlockMaterial PISTON_STICKY_BASE = new Solid("Sticky Piston", 29).setResistance(0.8F);
 	public static final BlockMaterial WEB = new Solid("Cobweb", 30).setHardness(4.0F).setResistance(20.0F);
-	public static final TallGrass TALL_GRASS = TallGrass.PARENT;	
+	public static final TallGrassMain TALL_GRASS = new TallGrassMain("Tall Grass");	
 	public static final BlockMaterial DEAD_BUSH = new LongGrass("Dead Shrubs", 32).setHardness(0.0F).setResistance(0.0F);
 	public static final BlockMaterial PISTON_BASE = new Solid("Piston", 33).setResistance(0.8F);
 	public static final BlockMaterial PISTON_EXTENSION = new Solid("Piston (Head)", 34).setResistance(0.8F);
-	public static final Wool WOOL = Wool.PARENT;
+	public static final WoolMain WOOL = new WoolMain("Wool");
 	public static final BlockMaterial MOVED_BY_PISTON = new Solid("Moved By Piston", 36).setResistance(0.0F);
 	public static final BlockMaterial DANDELION = new GroundAttachable("Dandelion", 37).setHardness(0.0F).setResistance(0.0F);
 	public static final BlockMaterial ROSE = new GroundAttachable("Rose", 38).setHardness(0.0F).setResistance(0.0F);
@@ -209,7 +208,7 @@ public final class VanillaMaterials {
 	public static final ItemMaterial RED_APPLE = new GenericFood("Apple", 260, 4, FoodEffectType.HUNGER);
 	public static final ItemMaterial BOW = new GenericRangedWeapon("Bow", 261, 1, 9, (short) 385);
 	public static final ItemMaterial ARROW = new GenericItem("Arrow", 262);
-	public static final Coal COAL = Coal.PARENT;	
+	public static final CoalMain COAL = new CoalMain("Coal");
 	public static final ItemMaterial DIAMOND = new GenericItem("Diamond", 264);
 	public static final ItemMaterial IRON_INGOT = new GenericItem("Iron Ingot", 265);
 	public static final ItemMaterial GOLD_INGOT = new GenericItem("Gold Ingot", 266);
@@ -297,7 +296,7 @@ public final class VanillaMaterials {
 	public static final ItemMaterial GLOWSTONE_DUST = new GenericItem("Glowstone Dust", 348);
 	public static final ItemMaterial RAW_FISH = new GenericFood("Raw Fish", 349, 2, FoodEffectType.HUNGER);
 	public static final ItemMaterial COOKED_FISH = new GenericFood("Cooked Fish", 350, 5, FoodEffectType.HUNGER);
-	public static final Dye DYE = Dye.PARENT;
+	public static final DyeMain DYE = new DyeMain("Dye");
 	public static final ItemMaterial BONE = new GenericItem("Bone", 352);
 	public static final ItemMaterial SUGAR = new GenericItem("Sugar", 353);
 	public static final ItemMaterial CAKE = new GenericBlockItem("Cake", 354, VanillaMaterials.CAKE_BLOCK);
@@ -363,7 +362,7 @@ public final class VanillaMaterials {
 	public static final ItemMaterial WHITE_MUSIC_DISC = new GenericItem("Music Disc", 2264);
 	public static final ItemMaterial FOREST_GREEN_MUSIC_DISC = new GenericItem("Music Disc", 2265);
 	public static final ItemMaterial BROKEN_MUSIC_DISC = new GenericItem("Music Disc", 2266);
-	public static final Potion POTION = Potion.PARENT;
+	public static final PotionMain POTION = new PotionMain("Potion");
 	
 	protected static void initialize() {
 		((GenericBlock) VanillaMaterials.STONE).setDrop(VanillaMaterials.COBBLESTONE);

--- a/src/main/java/org/spout/vanilla/material/block/TallGrass.java
+++ b/src/main/java/org/spout/vanilla/material/block/TallGrass.java
@@ -25,23 +25,24 @@
  */
 package org.spout.vanilla.material.block;
 
-public class TallGrass extends LongGrass {
-	public static final TallGrass PARENT = new TallGrass("Dead Grass");
-	public static final TallGrass DEAD_GRASS = PARENT;
-	public static final TallGrass TALL_GRASS = new TallGrass("Tall Grass", 1, PARENT);
-	public static final TallGrass FERN = new TallGrass("Fern", 2, PARENT);
+import org.spout.vanilla.material.main.TallGrassMain;
 
+public class TallGrass extends LongGrass {
 	public TallGrass(String name) {
 		super(name, 31);
 		this.setDefault();
 	}
 
-	private TallGrass(String name, int data, TallGrass parent) {
+	public TallGrass(String name, int data, TallGrassMain parent) {
 		super(name, 31, data, parent);
 		this.setDefault();
 	}
 
 	private void setDefault() {
 		this.setHardness(0.0F).setResistance(0.0F);
+	}
+	
+	public TallGrassMain getParentMaterial() {
+		return (TallGrassMain) super.getParentMaterial();
 	}
 }

--- a/src/main/java/org/spout/vanilla/material/block/Wool.java
+++ b/src/main/java/org/spout/vanilla/material/block/Wool.java
@@ -28,26 +28,9 @@ package org.spout.vanilla.material.block;
 import org.spout.api.material.DataSource;
 import org.spout.vanilla.material.MovingBlock;
 import org.spout.vanilla.material.generic.GenericBlock;
+import org.spout.vanilla.material.main.WoolMain;
 
 public class Wool extends GenericBlock implements MovingBlock {
-	public static final Wool PARENT = new Wool("White Wool");
-	public static final Wool WHITE = PARENT;
-	public static final Wool ORANGE = new Wool("Orange Wool", WoolColor.Orange, PARENT);
-	public static final Wool MAGENTA = new Wool("Magenta Wool", WoolColor.Magenta, PARENT);
-	public static final Wool LIGHTBLUE = new Wool("Light Blue Wool", WoolColor.LightBlue, PARENT);
-	public static final Wool YELLOW = new Wool("Yellow Wool", WoolColor.Yellow, PARENT);
-	public static final Wool LIME = new Wool("Lime Wool", WoolColor.Lime, PARENT);
-	public static final Wool PINK = new Wool("Pink Wool", WoolColor.Pink, PARENT);
-	public static final Wool GRAY = new Wool("Gray Wool", WoolColor.Gray, PARENT);
-	public static final Wool SILVER = new Wool("Silver Wool", WoolColor.Silver, PARENT);
-	public static final Wool CYAN = new Wool("Cyan Wool", WoolColor.Cyan, PARENT);
-	public static final Wool PURPLE = new Wool("Purple Wool", WoolColor.Purple, PARENT);
-	public static final Wool BLUE = new Wool("Blue Wool", WoolColor.Blue, PARENT);
-	public static final Wool BROWN = new Wool("Brown Wool", WoolColor.Brown, PARENT);
-	public static final Wool GREEN = new Wool("Green Wool", WoolColor.Green, PARENT);
-	public static final Wool RED = new Wool("Red Wool", WoolColor.Red, PARENT);
-	public static final Wool BLACK = new Wool("Black Wool", WoolColor.Black, PARENT);
-
 	public static enum WoolColor implements DataSource {
 		White(0),
 		Orange(1),
@@ -86,7 +69,7 @@ public class Wool extends GenericBlock implements MovingBlock {
 		this.color = WoolColor.White;
 	}
 
-	private Wool(String name, WoolColor color, Wool parent) {
+	public Wool(String name, WoolColor color, WoolMain parent) {
 		super(name, 35, color.getData(), parent);
 		this.setDefault();
 		this.color = color;
@@ -108,5 +91,10 @@ public class Wool extends GenericBlock implements MovingBlock {
 	@Override
 	public short getData() {
 		return this.color.getData();
+	}
+	
+	@Override
+	public WoolMain getParentMaterial() {
+		return (WoolMain) super.getParentMaterial();
 	}
 }

--- a/src/main/java/org/spout/vanilla/material/item/Coal.java
+++ b/src/main/java/org/spout/vanilla/material/item/Coal.java
@@ -26,17 +26,19 @@
 package org.spout.vanilla.material.item;
 
 import org.spout.vanilla.material.generic.GenericItem;
+import org.spout.vanilla.material.main.CoalMain;
 
 public class Coal extends GenericItem {
-	public static final Coal PARENT = new Coal("Coal");
-	public final Coal COAL = PARENT;
-	public final Coal CHARCOAL = new Coal("Charcoal", 1, PARENT);
-
 	public Coal(String name) {
 		super(name, 263);
 	}
 
-	private Coal(String name, int data, Coal parent) {
+	public Coal(String name, int data, CoalMain parent) {
 		super(name, 263, data, parent);
+	}
+
+	@Override
+	public CoalMain getParentMaterial() {
+		return (CoalMain) super.getParentMaterial();
 	}
 }

--- a/src/main/java/org/spout/vanilla/material/item/Dye.java
+++ b/src/main/java/org/spout/vanilla/material/item/Dye.java
@@ -31,26 +31,9 @@ import org.spout.api.material.DataSource;
 import org.spout.vanilla.entity.living.creature.passive.Sheep;
 import org.spout.vanilla.entity.living.player.SurvivalPlayer;
 import org.spout.vanilla.material.generic.GenericItem;
+import org.spout.vanilla.material.main.DyeMain;
 
 public class Dye extends GenericItem {
-	public static final Dye PARENT = new Dye("Ink Sac");
-	public final Dye INK_SAC = new Dye("Ink Sac", DyeColor.BLACK, PARENT);
-	public final Dye ROSE_RED = new Dye("Rose Red", DyeColor.RED, PARENT);
-	public final Dye CACTUS_GREEN = new Dye("Cactus Green", DyeColor.GREEN, PARENT);
-	public final Dye COCOA_BEANS = new Dye("Cocoa Beans", DyeColor.BROWN, PARENT);
-	public final Dye LAPIS_LAZULI = new Dye("Lapis Lazuli", DyeColor.BLUE, PARENT);
-	public final Dye PURPLE = new Dye("Purple Dye", DyeColor.PURPLE, PARENT);
-	public final Dye CYAN = new Dye("Cyan Dye", DyeColor.CYAN, PARENT);
-	public final Dye LIGHT_GRAY = new Dye("Light Gray Dye", DyeColor.LIGHT_GRAY, PARENT);
-	public final Dye GRAY = new Dye("Gray Dye", DyeColor.GRAY, PARENT);
-	public final Dye PINK = new Dye("Pink Dye", DyeColor.PINK, PARENT);
-	public final Dye LIME = new Dye("Lime Dye", DyeColor.LIME, PARENT);
-	public final Dye DANDELION_YELLOW = new Dye("Dandelion Yellow", DyeColor.YELLOW, PARENT);
-	public final Dye LIGHT_BLUE = new Dye("Light Blue Dye", DyeColor.LIGHT_BLUE, PARENT);
-	public final Dye MAGENTA = new Dye("Magenta Dye", DyeColor.MAGENTA, PARENT);
-	public final Dye ORANGE = new Dye("Orange Dye", DyeColor.ORANGE, PARENT);
-	public final Dye BONE_MEAL = new Dye("Bone Meal", DyeColor.WHITE, PARENT);
-
 	private final DyeColor color;
 
 	public static enum DyeColor implements DataSource {
@@ -88,7 +71,7 @@ public class Dye extends GenericItem {
 		this.color = DyeColor.BLACK;
 	}
 
-	private Dye(String name, DyeColor color, Dye parent) {
+	public Dye(String name, DyeColor color, DyeMain parent) {
 		super(name, 351, color.getData(), parent);
 		this.color = color;
 	}
@@ -122,5 +105,10 @@ public class Dye extends GenericItem {
 	@Override
 	public short getData() {
 		return this.color.getData();
+	}
+	
+	@Override
+	public DyeMain getParentMaterial() {
+		return (DyeMain) super.getParentMaterial();
 	}
 }

--- a/src/main/java/org/spout/vanilla/material/main/CoalMain.java
+++ b/src/main/java/org/spout/vanilla/material/main/CoalMain.java
@@ -23,22 +23,15 @@
  * License and see <http://www.spout.org/SpoutDevLicenseV1.txt> for the full license,
  * including the MIT license.
  */
-package org.spout.vanilla.material.item;
+package org.spout.vanilla.material.main;
 
-import org.spout.vanilla.material.generic.GenericItem;
-import org.spout.vanilla.material.main.PotionMain;
+import org.spout.vanilla.material.item.Coal;
 
-public class Potion extends GenericItem {
-	public Potion(String name) {
-		super(name, 373);
-	}
-
-	public Potion(String name, int data, PotionMain parent) {
-		super(name, 373, data, parent);
-	}
+public class CoalMain extends Coal {
+	public final Coal COAL = new Coal("Coal", 0, this);
+	public final Coal CHARCOAL = new Coal("Charcoal", 1, this);
 	
-	@Override
-	public PotionMain getParentMaterial() {
-		return (PotionMain) super.getParentMaterial();
+	public CoalMain(String name) {
+		super(name);
 	}
 }

--- a/src/main/java/org/spout/vanilla/material/main/DyeMain.java
+++ b/src/main/java/org/spout/vanilla/material/main/DyeMain.java
@@ -1,0 +1,51 @@
+/*
+ * This file is part of Vanilla (http://www.spout.org/).
+ *
+ * Vanilla is licensed under the SpoutDev License Version 1.
+ *
+ * Vanilla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In addition, 180 days after any changes are published, you can use the
+ * software, incorporating those changes, under the terms of the MIT license,
+ * as described in the SpoutDev License Version 1.
+ *
+ * Vanilla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License,
+ * the MIT license and the SpoutDev License Version 1 along with this program.
+ * If not, see <http://www.gnu.org/licenses/> for the GNU Lesser General Public
+ * License and see <http://www.spout.org/SpoutDevLicenseV1.txt> for the full license,
+ * including the MIT license.
+ */
+package org.spout.vanilla.material.main;
+
+import org.spout.vanilla.material.item.Dye;
+
+public class DyeMain extends Dye {
+	public final Dye INK_SAC = new Dye("Ink Sac", DyeColor.BLACK, this);
+	public final Dye ROSE_RED = new Dye("Rose Red", DyeColor.RED, this);
+	public final Dye CACTUS_GREEN = new Dye("Cactus Green", DyeColor.GREEN, this);
+	public final Dye COCOA_BEANS = new Dye("Cocoa Beans", DyeColor.BROWN, this);
+	public final Dye LAPIS_LAZULI = new Dye("Lapis Lazuli", DyeColor.BLUE, this);
+	public final Dye PURPLE = new Dye("Purple Dye", DyeColor.PURPLE, this);
+	public final Dye CYAN = new Dye("Cyan Dye", DyeColor.CYAN, this);
+	public final Dye LIGHT_GRAY = new Dye("Light Gray Dye", DyeColor.LIGHT_GRAY, this);
+	public final Dye GRAY = new Dye("Gray Dye", DyeColor.GRAY, this);
+	public final Dye PINK = new Dye("Pink Dye", DyeColor.PINK, this);
+	public final Dye LIME = new Dye("Lime Dye", DyeColor.LIME, this);
+	public final Dye DANDELION_YELLOW = new Dye("Dandelion Yellow", DyeColor.YELLOW, this);
+	public final Dye LIGHT_BLUE = new Dye("Light Blue Dye", DyeColor.LIGHT_BLUE, this);
+	public final Dye MAGENTA = new Dye("Magenta Dye", DyeColor.MAGENTA, this);
+	public final Dye ORANGE = new Dye("Orange Dye", DyeColor.ORANGE, this);
+	public final Dye BONE_MEAL = new Dye("Bone Meal", DyeColor.WHITE, this);
+
+	public DyeMain(String name) {
+		super(name);
+	}
+}

--- a/src/main/java/org/spout/vanilla/material/main/PotionMain.java
+++ b/src/main/java/org/spout/vanilla/material/main/PotionMain.java
@@ -1,0 +1,80 @@
+/*
+ * This file is part of Vanilla (http://www.spout.org/).
+ *
+ * Vanilla is licensed under the SpoutDev License Version 1.
+ *
+ * Vanilla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In addition, 180 days after any changes are published, you can use the
+ * software, incorporating those changes, under the terms of the MIT license,
+ * as described in the SpoutDev License Version 1.
+ *
+ * Vanilla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License,
+ * the MIT license and the SpoutDev License Version 1 along with this program.
+ * If not, see <http://www.gnu.org/licenses/> for the GNU Lesser General Public
+ * License and see <http://www.spout.org/SpoutDevLicenseV1.txt> for the full license,
+ * including the MIT license.
+ */
+package org.spout.vanilla.material.main;
+
+import org.spout.vanilla.material.item.Potion;
+
+public class PotionMain extends Potion {
+	public final Potion EMPTY = new Potion("Empty Potion", 0, this);
+	public final Potion AWKWARD = new Potion("Awkward Potion", 16, this);
+	public final Potion SPLASH_AWKWARD = new Potion("Splash Awkward Potion", 16384, this);
+	public final Potion THICK = new Potion("Thick Potion", 32, this);
+	public final Potion MUNDANE_EXTENDED = new Potion("Mundane Potion (Extended)", 64, this);
+	public final Potion MUNDANE = new Potion("Mundane Potion", 8192, this);
+	public final Potion REGENERATION_EXTENDED = new Potion("Potion of Regeneration (Extended)", 8193, this);
+	public final Potion SPLASH_REGENERATION_EXTENDED = new Potion("Splash Potion of Regeneration (Extended)", 16449, this);
+	public final Potion REGENERATION = new Potion("Potion of Regeneration", 8257, this);
+	public final Potion SPLASH_REGENERATION = new Potion("Splash Potion of Regeneration", 16385, this);
+	public final Potion REGENERATION_II = new Potion("Potion of Regeneration II", 8225, this);
+	public final Potion SPLASH_REGENERATION_II = new Potion("Splash Potion of Regeneration II", 16417, this);
+	public final Potion SWIFTNESS_EXTENDED = new Potion("Potion of Swiftness (Extended)", 8194, this);
+	public final Potion SPLASH_SWIFTNESS_EXTENDED = new Potion("Splash Potion of Swiftness (Extended)", 16450, this);
+	public final Potion SWIFTNESS = new Potion("Potion of Swiftness", 8258, this);
+	public final Potion SPLASH_SWIFTNESS = new Potion("Splash Potion of Swiftness", 16386, this);
+	public final Potion SWIFTNESS_II = new Potion("Potion of Swiftness II", 8226, this);
+	public final Potion SPLASH_SWIFTNESS_II = new Potion("Splash Potion of Swiftness II", 16418, this);
+	public final Potion FIRE_EXTENDED = new Potion("Potion of Fire Resistance (Extended)", 8194, this);
+	public final Potion SPLASH_FIRE_EXTENDED = new Potion("Splash Potion of Fire Resistance (Extended)", 16415, this);
+	public final Potion FIRE = new Potion("Potion of Fire Resistance", 8258, this);
+	public final Potion SPLASH_FIRE = new Potion("Splash Potion of Fire Resistance", 16387, this);
+	public final Potion FIRE_II = new Potion("Potion of Fire Resistance II", 8226, this);
+	public final Potion FIRE_REVERTED = new Potion("Potion of Fire Resistance", 8227, this);
+	public final Potion SPLASH_FIRE_REVERTED = new Potion("Splash Potion of Fire Resistance", 16419, this);
+	public final Potion HEALING = new Potion("Potion of Healing", 8197, this);
+	public final Potion SPLASH_HEALING = new Potion("Splash Potion of Healing", 16389, this);
+	public final Potion HEALING_REVERTED = new Potion("Potion of Healing", 8261, this);
+	public final Potion SPLASH_HEALING_REVERTED = new Potion("Splash Potion of Healing", 16453, this);
+	public final Potion HEALING_II = new Potion("Potion of Healing II", 8229, this);
+	public final Potion SPLASH_HEALING_II = new Potion("Splash Potion of Healing II", 16421, this);
+	public final Potion STRENGTH = new Potion("Potion of Strength", 8201, this);
+	public final Potion SPLASH_STRENGTH = new Potion("Splash Potion of Strength", 16393, this);
+	public final Potion STRENGTH_EXTENDED = new Potion("Potion of Strength (Extended)", 8265, this);
+	public final Potion SPLASH_STRENGTH_EXTENDED = new Potion("Spash Potion of Strength (Extended)", 16457, this);
+	public final Potion SLOWNESS_EXTENDED = new Potion("Potion of Slowness (Extended)", 8226, this);
+	public final Potion SPLASH_SLOWNESS_EXTENDED = new Potion("Splash Potion of Slowness (Extended)", 16458, this);
+	public final Potion SLOWNESS_REVERTED = new Potion("Potion of Slowness", 8234, this);
+	public final Potion SPLASH_SLOWNESS_REVERTED = new Potion("Splash Potion of Slowness", 16426, this);
+	public final Potion HARMING = new Potion("Potion of Harming", 8202, this);
+	public final Potion SPLASH_HARMING = new Potion("Splash Potion of Harming", 16396, this);
+	public final Potion HARMING_REVERTED = new Potion("Potion of Harming", 8264, this);
+	public final Potion SPLASH_HARMING_REVERTED = new Potion("Splash Potion of Harming", 16460, this);
+	public final Potion HARMING_II = new Potion("Potion of Harming II", 8236, this);
+	public final Potion SPLASH_HARMING_II = new Potion("Splash Potion of Harming", 16428, this);
+
+	public PotionMain(String name) {
+		super(name);
+	}
+}

--- a/src/main/java/org/spout/vanilla/material/main/TallGrassMain.java
+++ b/src/main/java/org/spout/vanilla/material/main/TallGrassMain.java
@@ -23,22 +23,16 @@
  * License and see <http://www.spout.org/SpoutDevLicenseV1.txt> for the full license,
  * including the MIT license.
  */
-package org.spout.vanilla.material.item;
+package org.spout.vanilla.material.main;
 
-import org.spout.vanilla.material.generic.GenericItem;
-import org.spout.vanilla.material.main.PotionMain;
+import org.spout.vanilla.material.block.TallGrass;
 
-public class Potion extends GenericItem {
-	public Potion(String name) {
-		super(name, 373);
-	}
+public class TallGrassMain extends TallGrass {
+	public final TallGrass DEAD_GRASS = new TallGrass("Dead Grass", 0, this);
+	public final TallGrass TALL_GRASS = new TallGrass("Tall Grass", 1, this);
+	public final TallGrass FERN = new TallGrass("Fern", 2, this);
 
-	public Potion(String name, int data, PotionMain parent) {
-		super(name, 373, data, parent);
-	}
-	
-	@Override
-	public PotionMain getParentMaterial() {
-		return (PotionMain) super.getParentMaterial();
+	public TallGrassMain(String name) {
+		super(name);
 	}
 }

--- a/src/main/java/org/spout/vanilla/material/main/WoolMain.java
+++ b/src/main/java/org/spout/vanilla/material/main/WoolMain.java
@@ -1,0 +1,52 @@
+/*
+ * This file is part of Vanilla (http://www.spout.org/).
+ *
+ * Vanilla is licensed under the SpoutDev License Version 1.
+ *
+ * Vanilla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In addition, 180 days after any changes are published, you can use the
+ * software, incorporating those changes, under the terms of the MIT license,
+ * as described in the SpoutDev License Version 1.
+ *
+ * Vanilla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License,
+ * the MIT license and the SpoutDev License Version 1 along with this program.
+ * If not, see <http://www.gnu.org/licenses/> for the GNU Lesser General Public
+ * License and see <http://www.spout.org/SpoutDevLicenseV1.txt> for the full license,
+ * including the MIT license.
+ */
+package org.spout.vanilla.material.main;
+
+import org.spout.vanilla.material.block.Wool;
+
+public class WoolMain extends Wool {
+	public final Wool WHITE = new Wool("White Wool", WoolColor.White, this);
+	public final Wool ORANGE = new Wool("Orange Wool", WoolColor.Orange, this);
+	public final Wool MAGENTA = new Wool("Magenta Wool", WoolColor.Magenta, this);
+	public final Wool LIGHTBLUE = new Wool("Light Blue Wool", WoolColor.LightBlue, this);
+	public final Wool YELLOW = new Wool("Yellow Wool", WoolColor.Yellow, this);
+	public final Wool LIME = new Wool("Lime Wool", WoolColor.Lime, this);
+	public final Wool PINK = new Wool("Pink Wool", WoolColor.Pink, this);
+	public final Wool GRAY = new Wool("Gray Wool", WoolColor.Gray, this);
+	public final Wool SILVER = new Wool("Silver Wool", WoolColor.Silver, this);
+	public final Wool CYAN = new Wool("Cyan Wool", WoolColor.Cyan, this);
+	public final Wool PURPLE = new Wool("Purple Wool", WoolColor.Purple, this);
+	public final Wool BLUE = new Wool("Blue Wool", WoolColor.Blue, this);
+	public final Wool BROWN = new Wool("Brown Wool", WoolColor.Brown, this);
+	public final Wool GREEN = new Wool("Green Wool", WoolColor.Green, this);
+	public final Wool RED = new Wool("Red Wool", WoolColor.Red, this);
+	public final Wool BLACK = new Wool("Black Wool", WoolColor.Black, this);
+	
+	public WoolMain(String name) {
+		super(name);
+	}
+
+}


### PR DESCRIPTION
Signed-off-by: berger killer bergerkiller@gmail.com

There were some circular reference (actually, constructor called in constructor) in the Dye and other classes. For simplicity; all sub-mats now have on separate Main class extending it, to prevent this. I noticed you used the static 'PARENT' before, but couldn't figure out why that would be useful.

You can always turn the separate 'constants' into an ' = this' assignment if that is better.
