### PR TITLE
More wgen/decorator tweaks

### DIFF
--- a/src/main/java/org/spout/vanilla/generator/normal/biome/DesertBiome.java
+++ b/src/main/java/org/spout/vanilla/generator/normal/biome/DesertBiome.java
@@ -60,7 +60,7 @@ public class DesertBiome extends VanillaBiomeType {
 		int y = chunkY * 16;
 		noise.setSeed((int) blockData.getWorld().getSeed());
 
-		int height = (int) ((noise.GetValue(x / 32.0 + 0.005, 0.05, z / 32.0 + 0.005) + 1.0) * 2.0 + 60.0);
+		int height = (int) ((noise.GetValue(x / 32.0 + 0.005, 0.05, z / 32.0 + 0.005) + 1.0) * 2.0 + 60.0 + 3.0);
 
 		for (int dy = y; dy < y + 16; dy++) {
 			short id = getBlockId(height, dy);

--- a/src/main/java/org/spout/vanilla/generator/normal/decorator/TreeDecorator.java
+++ b/src/main/java/org/spout/vanilla/generator/normal/decorator/TreeDecorator.java
@@ -71,15 +71,19 @@ public class TreeDecorator implements BiomeDecorator {
 		for (int k = 1; k <= oneWidth; k++) {
 			for (int i = -1; i <= 1; i++) {
 				for (int j = -1; j <= 1; j++) {
-					w.setBlockMaterial(cx + i, cy + height - k, cz + j, VanillaMaterials.LEAVES, c.getWorld());
+					if(w.getBlockMaterial(cx + i, cy + height - k, cz + j).equals(VanillaMaterials.AIR)) {
+						w.setBlockMaterial(cx + i, cy + height - k, cz + j, VanillaMaterials.LEAVES, c.getWorld());
+					}
 				}
 			}
 		}
 		for (int k = oneWidth + 1; k <= oneWidth + twoWidth; k++) {
 			for (int i = -2; i <= 2; i++) {
 				for (int j = -2; j <= 2; j++) {
-					if(!(j == -2 && i == -2) && !(j == 2 && i == -2) && !(j == -2 && i == 2) && !(j == 2 && i == 2)) {
-						w.setBlockMaterial(cx + i, cy + height - k, cz + j, VanillaMaterials.LEAVES, c.getWorld());
+					if(w.getBlockMaterial(cx + i, cy + height - k, cz + j).equals(VanillaMaterials.AIR)) {
+						if(!(j == -2 && i == -2) && !(j == 2 && i == -2) && !(j == -2 && i == 2) && !(j == 2 && i == 2)) {
+							w.setBlockMaterial(cx + i, cy + height - k, cz + j, VanillaMaterials.LEAVES, c.getWorld());
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Signed-off-by: Devon Endicott dephurites@gmail.com

Made the desert not generate lower than the sea-level by just raising it all by four blocks
Made it so that the leaves made by trees don't overwrite existing blocks, meaning that they can only replace air
