### PR TITLE
Improved minecart and track logic some more

### DIFF
--- a/src/main/java/org/spout/vanilla/controller/object/MovingSubstance.java
+++ b/src/main/java/org/spout/vanilla/controller/object/MovingSubstance.java
@@ -29,8 +29,8 @@ import org.spout.api.math.Vector3;
 import org.spout.vanilla.controller.VanillaControllerType;
 
 public abstract class MovingSubstance extends Substance {
-	private Vector3 movedVelocity;
-	private Vector3 velocity;
+	private Vector3 movedVelocity = Vector3.ZERO;
+	private Vector3 velocity = Vector3.ZERO;
 	private float maxSpeed; //might turn this into a vector too?
 
 	protected MovingSubstance(VanillaControllerType type) {

--- a/src/main/java/org/spout/vanilla/controller/object/vehicle/Minecart.java
+++ b/src/main/java/org/spout/vanilla/controller/object/vehicle/Minecart.java
@@ -262,22 +262,11 @@ public abstract class Minecart extends MovingSubstance implements Vehicle {
 					velocity = velocity.add(velocity.multiply(0.06D / velLength));
 				} else {
 					//push a minecart slightly forward when hitting a solid block
-					BlockFace pushDirection = null;
-					if (this.railData.getState() == RailsState.SOUTH) {
-						if (this.railsBlock.clone().move(BlockFace.SOUTH).getMaterial() instanceof Solid) {
-							pushDirection = BlockFace.NORTH;
-						} else if (this.railsBlock.clone().move(BlockFace.NORTH).getMaterial() instanceof Solid) {
-							pushDirection = BlockFace.SOUTH;
+					for (BlockFace dir : this.railData.getDirections()) {
+						if (this.railsBlock.clone().move(dir).getMaterial() instanceof Solid) {
+							velocity = dir.getOpposite().getOffset().toVector2().multiply(0.02);
+							break;
 						}
-					} else if (this.railData.getState() == RailsState.WEST) {
-						if (this.railsBlock.clone().move(BlockFace.WEST).getMaterial() instanceof Solid) {
-							pushDirection = BlockFace.EAST;
-						} else if (this.railsBlock.clone().move(BlockFace.EAST).getMaterial() instanceof Solid) {
-							pushDirection = BlockFace.WEST;
-						}
-					}
-					if (pushDirection != null) {
-						velocity = pushDirection.getOffset().toVector2().multiply(0.02);
 					}
 				}
 			}

--- a/src/main/java/org/spout/vanilla/material/VanillaMaterials.java
+++ b/src/main/java/org/spout/vanilla/material/VanillaMaterials.java
@@ -47,6 +47,7 @@ import org.spout.vanilla.material.block.Plank;
 import org.spout.vanilla.material.block.Sandstone;
 import org.spout.vanilla.material.block.Sapling;
 import org.spout.vanilla.material.block.Slab;
+import org.spout.vanilla.material.block.Snow;
 import org.spout.vanilla.material.block.Solid;
 import org.spout.vanilla.material.block.StoneBrick;
 import org.spout.vanilla.material.block.TallGrass;
@@ -158,7 +159,7 @@ public final class VanillaMaterials {
 	public static final RedstoneTorch REDSTONE_TORCH_OFF = (RedstoneTorch) register(new RedstoneTorch("Redstone Torch", 75, false).setHardness(0.0F).setResistance(0.0F));
 	public static final RedstoneTorch REDSTONE_TORCH_ON = (RedstoneTorch) register(new RedstoneTorch("Redstone Torch (On)", 76, true).setHardness(0.0F).setResistance(0.0F).setLightLevel(7));
 	public static final Solid STONE_BUTTON = (Solid) register(new Solid("Stone Button", 77).setHardness(0.5F).setResistance(0.8F));
-	public static final Solid SNOW = (Solid) register(new Solid("Snow", 78).setHardness(0.1F).setResistance(0.2F));
+	public static final Snow SNOW = (Snow) register(new Snow("Snow").setHardness(0.1F).setResistance(0.2F));
 	public static final Ice ICE = (Ice) register(new Ice("Ice", 79).setHardness(0.5F).setResistance(0.8F));
 	public static final Solid SNOW_BLOCK = (Solid) register(new Solid("Snow Block", 80).setHardness(0.2F).setResistance(0.3F));
 	public static final Cactus CACTUS = (Cactus) register(new Cactus("Cactus", 81).setHardness(0.4F).setResistance(0.7F));

--- a/src/main/java/org/spout/vanilla/material/block/Snow.java
+++ b/src/main/java/org/spout/vanilla/material/block/Snow.java
@@ -1,0 +1,40 @@
+/*
+ * This file is part of Vanilla (http://www.spout.org/).
+ *
+ * Vanilla is licensed under the SpoutDev License Version 1.
+ *
+ * Vanilla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In addition, 180 days after any changes are published, you can use the
+ * software, incorporating those changes, under the terms of the MIT license,
+ * as described in the SpoutDev License Version 1.
+ *
+ * Vanilla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License,
+ * the MIT license and the SpoutDev License Version 1 along with this program.
+ * If not, see <http://www.gnu.org/licenses/> for the GNU Lesser General Public
+ * License and see <http://www.spout.org/SpoutDevLicenseV1.txt> for the full license,
+ * including the MIT license.
+ */
+package org.spout.vanilla.material.block;
+
+import org.spout.vanilla.material.generic.GenericBlock;
+
+public class Snow extends GenericBlock {
+
+	public Snow(String name) {
+		super(name, 78);
+	}
+	
+	@Override
+	public boolean isPlacementObstacle() {
+		return false;
+	}
+}

--- a/src/main/java/org/spout/vanilla/util/RailsState.java
+++ b/src/main/java/org/spout/vanilla/util/RailsState.java
@@ -38,10 +38,10 @@ public enum RailsState {
 	NORTH_SLOPED(BlockFace.NORTH, BlockFace.SOUTH, true),
 	EAST_SLOPED(BlockFace.EAST, BlockFace.WEST, true),
 	WEST_SLOPED(BlockFace.WEST, BlockFace.EAST, true),
+	SOUTH_WEST(BlockFace.SOUTH, BlockFace.WEST, false),
 	NORTH_WEST(BlockFace.NORTH, BlockFace.WEST, false),
 	NORTH_EAST(BlockFace.NORTH, BlockFace.EAST, false),
-	SOUTH_EAST(BlockFace.SOUTH, BlockFace.EAST, false),
-	SOUTH_WEST(BlockFace.SOUTH, BlockFace.WEST, false);
+	SOUTH_EAST(BlockFace.SOUTH, BlockFace.EAST, false);
 	private final BlockFace[] directions;
 	private final boolean curved;
 	private final boolean sloped;


### PR DESCRIPTION
Signed-off-by: berger killer bergerkiller@gmail.com

Fixed a NPE and track logic now properly connects at all time. Instead of performing a single update on all neighbouring rails, it will instead check all neighbours for connections. If it has less than 2 connections, it can connect and is added as neighbour. Finally the main rails looks at all (valid) neighbours and decides a valid rails state. During this, it also forces all 'connected' rails to connect to him, which the neighbours themselves resolve.
