### PR TITLE
saturation is float, not short

### DIFF
--- a/src/main/java/org/spout/vanilla/protocol/event/entity/player/PlayerHealthEvent.java
+++ b/src/main/java/org/spout/vanilla/protocol/event/entity/player/PlayerHealthEvent.java
@@ -58,7 +58,7 @@ public class PlayerHealthEvent extends ProtocolEvent {
 		return saturation;
 	}
 
-	public void setFoodSaturation(short saturation) {
+	public void setFoodSaturation(float saturation) {
 		this.saturation = saturation;
 	}
 }


### PR DESCRIPTION
In this new file, method setFoodSaturation had short for saturation. saturation is a float.
