### PR TITLE
Add real Minecraft health+hunger handling.

### DIFF
--- a/src/main/java/org/spout/vanilla/controller/living/player/VanillaPlayer.java
+++ b/src/main/java/org/spout/vanilla/controller/living/player/VanillaPlayer.java
@@ -156,25 +156,23 @@ public class VanillaPlayer extends Human implements PlayerController {
 	private void updateHealth() {
 		short health;
 		Entity parent = getParent();
-		foodSaturation -= 0.1;
 		health = (short) parent.getHealth();
-		if (foodSaturation <= 0) {
-			hunger--;
-		} else {
-			health++;
-		}
 
-		if (exhaustion >= 4.0) {
+		if (exhaustion > 4.0) {
 			exhaustion = 0;
-			if (foodSaturation <= 0) {
-				hunger--;
+			if (foodSaturation > 0) {
+				foodSaturation = Math.max(foodSaturation - 1, 0);
 			} else {
-				foodSaturation--;
+				hunger = (short) Math.max(hunger - 1, 0);
 			}
 		}
 
 		if (hunger <= 0) {
-			health--;
+			health = (short) Math.max(health - 1, 0);
+			parent.setHealth(health, new HealthChangeReason(HealthChangeReason.Type.STARVE));
+		} else if (hunger >= 18) {
+			health = (short) Math.min(health + 1, 20);
+			parent.setHealth(health, new HealthChangeReason(HealthChangeReason.Type.REGENERATION));
 		}
 
 		System.out.println("Performing health/hunger update...");
@@ -182,7 +180,6 @@ public class VanillaPlayer extends Human implements PlayerController {
 		System.out.println("Hunger: " + hunger);
 		System.out.println("Health: " + health);
 		System.out.println("Exhaustion: " + exhaustion);
-		parent.setHealth(health, new HealthChangeReason(HealthChangeReason.Type.REGENERATION));
 		sendPacket(owner, new PlayerHealthMessage(health, hunger, foodSaturation));
 	}
 	

--- a/src/main/java/org/spout/vanilla/controller/source/HealthChangeReason.java
+++ b/src/main/java/org/spout/vanilla/controller/source/HealthChangeReason.java
@@ -57,6 +57,10 @@ public class HealthChangeReason extends Reason {
 		 */
 		SPAWN,
 		/**
+		 * Health changed due to starvation.
+		 */
+		STARVE,
+		/**
 		 * Health changed due to some unknown reason.
 		 */
 		UNKNOWN;


### PR DESCRIPTION
The current way of handling health is really strange. Based on my testing, this is how Minecraft handles hunger, except for one small thing: I don't think exhaustion is supposed to be set back to 0. I think it is supposed to have 4 subtracted from it, however any time I tried to do that I just ended up with it adding 4 to exhaustion for some strange reason beyond my understanding.

TODO: Proper handling of exhaustion. adding 0.1 every tick is definitely not right, seeing how fast hunger drains out now.
