### PR TITLE
Fixes issue VANILLA-71

### DIFF
--- a/src/main/java/org/spout/vanilla/command/AdministrationCommands.java
+++ b/src/main/java/org/spout/vanilla/command/AdministrationCommands.java
@@ -146,6 +146,9 @@ public class AdministrationCommands {
 				data = Short.parseShort(parts[1]);
 			} else {
 				material = Material.get(args.getString(index));
+				if (material != null) {
+					data = material.getData();
+				}
 			}
 		}
 


### PR DESCRIPTION
Fixed the issue with /give <itemnamehere> not assigning the item data to the given item.

Link to issue http://issues.spout.org/browse/VANILLA-71

Signed-off-by: Josh Latimer joshgesh@gmail.com
