### PR TITLE
Smooth populator fix

### DIFF
--- a/src/main/java/org/spout/vanilla/material/block/solid/Pumpkin.java
+++ b/src/main/java/org/spout/vanilla/material/block/solid/Pumpkin.java
@@ -1,3 +1,29 @@
+/*
+ * This file is part of Vanilla.
+ *
+ * Copyright (c) 2011-2012, SpoutDev <http://www.spout.org/>
+ * Vanilla is licensed under the SpoutDev License Version 1.
+ *
+ * Vanilla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In addition, 180 days after any changes are published, you can use the
+ * software, incorporating those changes, under the terms of the MIT license,
+ * as described in the SpoutDev License Version 1.
+ *
+ * Vanilla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License,
+ * the MIT license and the SpoutDev License Version 1 along with this program.
+ * If not, see <http://www.gnu.org/licenses/> for the GNU Lesser General Public
+ * License and see <http://www.spout.org/SpoutDevLicenseV1.txt> for the full license,
+ * including the MIT license.
+ */
 package org.spout.vanilla.material.block.solid;
 
 import org.spout.api.geo.cuboid.Block;

--- a/src/main/java/org/spout/vanilla/world/populator/SmoothPopulator.java
+++ b/src/main/java/org/spout/vanilla/world/populator/SmoothPopulator.java
@@ -45,6 +45,7 @@ import org.spout.vanilla.material.block.Liquid;
  * the borders between biomes.
  */
 public class SmoothPopulator implements Populator {
+	
 	// area to smooth per populate call
 	private final static byte SMOOTH_SIZE = 16;
 	// the floor of half the value of the side of the square
@@ -82,11 +83,13 @@ public class SmoothPopulator implements Populator {
 		for (byte x = 0; x < SMOOTH_SIZE; x++) {
 			for (byte z = 0; z < SMOOTH_SIZE; z++) {
 				byte y = getHighestNonFluidBlock(world, worldX + x, worldZ + z);
-				final Biome currentBiome = world.getBiomeType(worldX + x, y, worldZ + z);
-				if (lastBiome != null) {
-					hasBiomeVariations = currentBiome != lastBiome;
+				if (!hasBiomeVariations) {
+					final Biome currentBiome = world.getBiomeType(worldX + x, y, worldZ + z);
+					if (lastBiome != null) {
+						hasBiomeVariations = currentBiome != lastBiome;
+					}
+					lastBiome = currentBiome;
 				}
-				lastBiome = currentBiome;
 				heightMap[x + z * SMOOTH_SIZE] = y;
 			}
 		}
@@ -127,16 +130,6 @@ public class SmoothPopulator implements Populator {
 		return y;
 	}
 
-	/*private void mark(World world, int x, int z) {
-		 byte y = 127;
-		 while (world.getBlockMaterial(x, y, z) == VanillaMaterials.AIR) {
-		 y--;
-		 if (y == 0) {
-		 return;
-		 }
-		 }
-		 world.setBlockMaterial(x, y, z, VanillaMaterials.GOLD_BLOCK, (short) 0, world);
-		 }*/
 	// get the lowest non bedrock block, at world level
 	private byte getLowestNonBedrockBlock(World world, int x, int z) {
 		byte y = 0;
@@ -208,10 +201,10 @@ public class SmoothPopulator implements Populator {
 	// with the most present adjacent liquid
 	private void fixAdjacentLiquids(World world, int x, int y, int z) {
 		final BlockMaterial[] adjacent = {
-				world.getBlockMaterial(x - 1, y, z),
-				world.getBlockMaterial(x + 1, y, z),
-				world.getBlockMaterial(x, y, z - 1),
-				world.getBlockMaterial(x, y, z + 1)
+			world.getBlockMaterial(x - 1, y, z),
+			world.getBlockMaterial(x + 1, y, z),
+			world.getBlockMaterial(x, y, z - 1),
+			world.getBlockMaterial(x, y, z + 1)
 		};
 		boolean hasAdjacentLiquid = false;
 		for (BlockMaterial material : adjacent) {


### PR DESCRIPTION
Make sure to stop checking for biome variations once it's been found to have some (so, stop using the last variation check, which might not represent the entire area).

Terrain generation looks a bit better now.
:D

Yeah, it's not a listed issue for the feature freeze, but it's an important fix.

Also, added a missing license header.

I've just completed the HugeTreeObject, should I make a PR, or wait for the end of the feature freeze?

Signed-off-by: Aleksi Sapon QcTechs@gmail.com
