### PR TITLE
Tweaked the biome selector.

### DIFF
--- a/src/main/java/org/spout/vanilla/world/generator/VanillaBiome.java
+++ b/src/main/java/org/spout/vanilla/world/generator/VanillaBiome.java
@@ -31,10 +31,6 @@ import org.spout.api.generator.biome.Decorator;
 
 public abstract class VanillaBiome extends Biome {
 	private final int biomeId;
-	//TODO: actually implement these in the selector instead of hard coding them in
-	private float minTemp = 0f, maxTemp = 0f;
-	private float minHumiditiy = 0f, maxHumidity = 0f;
-	private float minElevation = 0f, maxElevation = 0f;
 
 	protected VanillaBiome(int biomeId, Decorator... decorators) {
 		super(decorators);
@@ -43,47 +39,5 @@ public abstract class VanillaBiome extends Biome {
 
 	public int getBiomeId() {
 		return biomeId;
-	}
-
-	public float getMinTemp() {
-		return this.minTemp;
-	}
-
-	public float getMaxTemp() {
-		return this.maxTemp;
-	}
-
-	public float getMinHumiditiy() {
-		return this.minHumiditiy;
-	}
-
-	public float getMaxHumidity() {
-		return this.maxHumidity;
-	}
-
-	public float getMinElevation() {
-		return this.minElevation;
-	}
-
-	public float getMaxElevation() {
-		return this.maxElevation;
-	}
-
-	public VanillaBiome setTemp(float min, float max) {
-		this.minTemp = min;
-		this.maxTemp = max;
-		return this;
-	}
-
-	public VanillaBiome setHumidity(float min, float max) {
-		this.minHumiditiy = min;
-		this.maxHumidity = max;
-		return this;
-	}
-
-	public VanillaBiome setElevation(float min, float max) {
-		this.minElevation = min;
-		this.maxElevation = max;
-		return this;
 	}
 }

--- a/src/main/java/org/spout/vanilla/world/generator/normal/NormalGenerator.java
+++ b/src/main/java/org/spout/vanilla/world/generator/normal/NormalGenerator.java
@@ -45,7 +45,7 @@ public class NormalGenerator extends BiomeGenerator implements VanillaGenerator 
 
 	@Override
 	public void registerBiomes() {
-		selector = new VanillaBiomeSelector(this, 2.0f);
+		selector = new VanillaBiomeSelector(2.0, 2.0, 0.35, 0.05, false);
 		setSelector(selector);
 		addPopulator(new SmoothPopulator());
 		register(VanillaBiomes.OCEAN);

--- a/src/main/java/org/spout/vanilla/world/selector/VanillaBiomeSelector.java
+++ b/src/main/java/org/spout/vanilla/world/selector/VanillaBiomeSelector.java
@@ -34,52 +34,46 @@ import net.royawesome.jlibnoise.module.source.Billow;
 import net.royawesome.jlibnoise.module.source.Const;
 import net.royawesome.jlibnoise.module.source.Perlin;
 import net.royawesome.jlibnoise.module.source.RidgedMulti;
-import net.royawesome.jlibnoise.module.source.Voronoi;
 
 import org.spout.api.generator.biome.Biome;
-import org.spout.api.generator.biome.BiomeGenerator;
 import org.spout.api.generator.biome.BiomeSelector;
 
 import org.spout.vanilla.world.generator.VanillaBiomes;
 
 public class VanillaBiomeSelector extends BiomeSelector {
-	private final BiomeGenerator parentGenerator;
-	private final float scale;
-	private final Voronoi rainfall;
-	private final Perlin temperature;
+	private final double scale;
+	private final Perlin temperature, rainfall;
 	private final RidgedMulti mountain;
 	private final Billow continentSelector;
 	private final Billow hills;
 	private final Clamp finalRainfall;
 	private final Clamp finalTemp;
-	private final Select finalElevationNoise;
+	private final Select oceanBeachDivide, finalElevationNoise;
 
 	/**
-	 * Selects biomes based on Whittaker's humidity-temperature model.
-	 * @param scale Make this bigger if you'd like bigger biomes.
+	 * Selects biomes based on Whittaker's humidity-temperature diagram.
 	 */
-	public VanillaBiomeSelector(BiomeGenerator parentGenerator, float scale) {
-		this.parentGenerator = parentGenerator;
+	public VanillaBiomeSelector(double scale, double biomeScale, double oceanBoundary, double beachBoundary, boolean hasMountains) {
 		this.scale = scale;
 		//Creates the noise for rainfall distribution
-		rainfall = new Voronoi();
-		rainfall.setDisplacement(1.0);
-		rainfall.setFrequency(1.0);
+		rainfall = new Perlin();
+		rainfall.setFrequency(0.4 / biomeScale);
+		rainfall.setOctaveCount(4);
 		final ScaleBias rainfallModifier = new ScaleBias();
 		rainfallModifier.SetSourceModule(0, rainfall);
 		rainfallModifier.setScale(0.5);
 		rainfallModifier.setBias(0.5);
 		final Turbulence rainfallTurbulence = new Turbulence();
 		rainfallTurbulence.SetSourceModule(0, rainfallModifier);
-		rainfallTurbulence.setFrequency(0.5);
-		rainfallTurbulence.setPower(0.75);
+		rainfallTurbulence.setFrequency(0.4);
+		rainfallTurbulence.setPower(0.6);
 		finalRainfall = new Clamp();
 		finalRainfall.SetSourceModule(0, rainfallTurbulence);
 		finalRainfall.setLowerBound(0);
 		finalRainfall.setUpperBound(1.0);
 		//Creates the noise module for temperature distribution
 		temperature = new Perlin();
-		temperature.setFrequency(0.4);
+		temperature.setFrequency(0.4 / biomeScale);
 		temperature.setOctaveCount(4);
 		final ScaleBias tempModifier = new ScaleBias();
 		tempModifier.SetSourceModule(0, temperature);
@@ -120,16 +114,20 @@ public class VanillaBiomeSelector extends BiomeSelector {
 		hillsClamp.setLowerBound(0);
 		hillsClamp.setUpperBound(0.65);
 		//Puts the elevation noises together
-		final Select mountainRangeSelector = new Select();
-		mountainRangeSelector.SetSourceModule(1, mountainModifier);
-		mountainRangeSelector.SetSourceModule(0, hillsClamp);
-		mountainRangeSelector.setControlModule(mountainModifier);
-		mountainRangeSelector.setBounds(100, 0.75);
-		mountainRangeSelector.setEdgeFalloff(0.4);
 		final Clamp elevationClamp = new Clamp();
-		elevationClamp.SetSourceModule(0, mountainRangeSelector);
-		elevationClamp.setLowerBound(0.11); //just more than for beach biomes
-		elevationClamp.setUpperBound(1.0);
+		if (hasMountains) {
+			final Select mountainRangeSelector = new Select();
+			mountainRangeSelector.SetSourceModule(1, mountainModifier);
+			mountainRangeSelector.SetSourceModule(0, hillsClamp);
+			mountainRangeSelector.setControlModule(mountainModifier);
+			mountainRangeSelector.setBounds(100, 0.75);
+			mountainRangeSelector.setEdgeFalloff(0.4);
+			elevationClamp.SetSourceModule(0, mountainRangeSelector);
+			elevationClamp.setLowerBound(0.11); //just more than for beach biomes
+			elevationClamp.setUpperBound(1.0);
+		} else {
+			elevationClamp.SetSourceModule(0, hillsClamp);
+		}
 		//Creates the noise module for separating continents & oceans
 		continentSelector = new Billow();
 		continentSelector.setFrequency(0.2);
@@ -139,17 +137,17 @@ public class VanillaBiomeSelector extends BiomeSelector {
 		continentSelectorModifier.setScale(0.5);
 		continentSelectorModifier.setBias(0.5);
 		//Divides the ocean and continents, starting with the beach level
-		final Select oceanBeachDivide = new Select();
+		oceanBeachDivide = new Select();
 		oceanBeachDivide.SetSourceModule(0, uniformOcean);
 		oceanBeachDivide.SetSourceModule(1, shoreline);
 		oceanBeachDivide.setControlModule(continentSelectorModifier);
-		oceanBeachDivide.setBounds(100, 0.52);
+		oceanBeachDivide.setBounds(100, oceanBoundary);
 		//Creates the final elevation noise for biome selection
 		finalElevationNoise = new Select();
 		finalElevationNoise.SetSourceModule(0, oceanBeachDivide);
 		finalElevationNoise.SetSourceModule(1, elevationClamp);
 		finalElevationNoise.setControlModule(continentSelectorModifier);
-		finalElevationNoise.setBounds(100, 0.55);
+		finalElevationNoise.setBounds(100, oceanBoundary + beachBoundary);
 	}
 
 	@Override
@@ -159,145 +157,92 @@ public class VanillaBiomeSelector extends BiomeSelector {
 		temperature.setSeed((int) seed * 7);
 		mountain.setSeed((int) seed * 5);
 		hills.setSeed((int) seed * 13);
-		final double divisor = scale * 128.0;
-		final double elevation = finalElevationNoise.GetValue(x / divisor + 0.05, 0.05, z / divisor + 0.05);
-		final double rain = finalRainfall.GetValue(x / divisor + 0.05, 0.05, z / divisor + 0.05);
-		final double temp = finalTemp.GetValue(x / divisor + 0.05, 0.05, z / divisor + 0.05);
-		//TODO: make these conditions use the values from the biome classes themselves
-		return getWhittakerBiome(elevation, temp, rain);
-	}
 
-	private Biome getWhittakerBiome(double elevation, double temp, double rain) {
+		final double elevation = getElevation(x,z);
+		final double rain = getAvgRainfall(x,z);
+		final double temp = getAvgTemperature(x,z);
+
 		if (elevation > 0.8) {
-			if (parentGenerator.getBiomes().contains(VanillaBiomes.MOUNTAINS)) {
-				return VanillaBiomes.MOUNTAINS; //mountains
-			} else {
-				return VanillaBiomes.OCEAN;
-			}
+			return VanillaBiomes.MOUNTAINS; //mountains
 		} else if (elevation > 0.65) {
-			if (parentGenerator.getBiomes().contains(VanillaBiomes.SMALL_MOUNTAINS)) {
-				return VanillaBiomes.SMALL_MOUNTAINS; //small mountains
-			} else {
-				return VanillaBiomes.OCEAN;
-			}
+			return VanillaBiomes.SMALL_MOUNTAINS; //small mountains
 		} else if (elevation == 0.1) {
 			if (rain > 0.6) {
-				if (parentGenerator.getBiomes().contains(VanillaBiomes.SWAMP)) {
-					return VanillaBiomes.SWAMP; //swamp
-				} else {
-					return VanillaBiomes.OCEAN;
-				}
+				return VanillaBiomes.SWAMP; //swamp
 			} else {
-				if (parentGenerator.getBiomes().contains(VanillaBiomes.BEACH)) {
-					return VanillaBiomes.BEACH; //beach
-				} else {
-					return VanillaBiomes.OCEAN;
-				}
+				return VanillaBiomes.BEACH; //beach
 			}
 		} else if (elevation == -1) {
 			return VanillaBiomes.OCEAN; //ocean
 		} else {
 			if (temp < 0.2) {
 				if (rain > 0.6) {
-					if (parentGenerator.getBiomes().contains(VanillaBiomes.TAIGA)) {
-						return VanillaBiomes.TAIGA; //taiga
-					} else {
-						return VanillaBiomes.OCEAN;
-					}
+					return VanillaBiomes.TAIGA; //taiga
 				} else {
-					if (parentGenerator.getBiomes().contains(VanillaBiomes.TUNDRA)) {
-						return VanillaBiomes.TUNDRA; //tundra
-					} else {
-						return VanillaBiomes.OCEAN;
-					}
+					return VanillaBiomes.TUNDRA; //tundra
 				}
 			} else if (temp < 0.4) {
 				if (rain > 0.6) {
-					if (parentGenerator.getBiomes().contains(VanillaBiomes.FOREST)) {
-						return VanillaBiomes.FOREST; //forest
-					} else {
-						return VanillaBiomes.OCEAN;
-					}
+					return VanillaBiomes.FOREST; //forest
 				} else {
-					if (parentGenerator.getBiomes().contains(VanillaBiomes.TAIGA)) {
-						return VanillaBiomes.TAIGA; //taiga
-					} else {
-						return VanillaBiomes.OCEAN;
-					}
+					return VanillaBiomes.TAIGA; //taiga
 				}
 			} else if (temp < 0.6) {
 				if (rain > 0.8) {
-					if (parentGenerator.getBiomes().contains(VanillaBiomes.JUNGLE)) {
-						return VanillaBiomes.JUNGLE; //jungle
-					} else {
-						return VanillaBiomes.OCEAN;
-					}
+					return VanillaBiomes.JUNGLE; //jungle
 				} else if (rain > 0.4) {
-					if (parentGenerator.getBiomes().contains(VanillaBiomes.FOREST)) {
-						return VanillaBiomes.FOREST; //forest
-					} else {
-						return VanillaBiomes.OCEAN;
-					}
+					return VanillaBiomes.FOREST; //forest
 				} else {
-					if (parentGenerator.getBiomes().contains(VanillaBiomes.PLAIN)) {
-						return VanillaBiomes.PLAIN; //plains
-					} else {
-						return VanillaBiomes.OCEAN;
-					}
+					return VanillaBiomes.PLAIN; //plains
 				}
 			} else if (temp < 0.8) {
 				if (rain > 0.8) {
-					if (parentGenerator.getBiomes().contains(VanillaBiomes.JUNGLE)) {
-						return VanillaBiomes.JUNGLE; //jungle
-					} else {
-						return VanillaBiomes.OCEAN;
-					}
+					return VanillaBiomes.JUNGLE; //jungle
 				} else if (rain > 0.6) {
-					if (parentGenerator.getBiomes().contains(VanillaBiomes.FOREST)) {
-						return VanillaBiomes.FOREST; //forest
-					} else {
-						return VanillaBiomes.OCEAN;
-					}
+					return VanillaBiomes.FOREST; //forest
 				} else if (rain > 0.2) {
-					if (parentGenerator.getBiomes().contains(VanillaBiomes.PLAIN)) {
-						return VanillaBiomes.PLAIN; //plains
-					} else {
-						return VanillaBiomes.OCEAN;
-					}
+					return VanillaBiomes.PLAIN; //plains
 				} else {
-					if (parentGenerator.getBiomes().contains(VanillaBiomes.DESERT)) {
-						return VanillaBiomes.DESERT; //desert
-					} else {
-						return VanillaBiomes.OCEAN;
-					}
+					return VanillaBiomes.DESERT; //desert
 				}
 			} else {
 				if (rain > 0.8) {
-					if (parentGenerator.getBiomes().contains(VanillaBiomes.JUNGLE)) {
-						return VanillaBiomes.JUNGLE; //jungle
-					} else {
-						return VanillaBiomes.OCEAN;
-					}
+					return VanillaBiomes.JUNGLE; //jungle
 				} else if (rain > 0.6) {
-					if (parentGenerator.getBiomes().contains(VanillaBiomes.FOREST)) {
-						return VanillaBiomes.FOREST; //forest
-					} else {
-						return VanillaBiomes.OCEAN;
-					}
+					return VanillaBiomes.FOREST; //forest
 				} else if (rain > 0.4) {
-					if (parentGenerator.getBiomes().contains(VanillaBiomes.PLAIN)) {
-						return VanillaBiomes.PLAIN; //plains
-					} else {
-						return VanillaBiomes.OCEAN;
-					}
+					return VanillaBiomes.PLAIN; //plains
 				} else {
-					if (parentGenerator.getBiomes().contains(VanillaBiomes.DESERT)) {
-						return VanillaBiomes.DESERT; //desert
-					} else {
-						return VanillaBiomes.OCEAN;
-					}
+					return VanillaBiomes.DESERT; //desert
 				}
 			}
 		}
+	}
+
+	/**
+	 * Returns the raw elevation noise value [0-1] for a given location.
+	 * @param x The x coordinate of the location.
+	 * @param z The z coordinate of the location.
+	 */
+	public double getElevation(int x, int z) {
+		return finalElevationNoise.GetValue(x / (scale * 128.0) + 0.05, 0.05, z / (scale * 128.0) + 0.05);
+	}
+
+	/**
+	 * Returns the raw rainfall noise value [0-1] for a given location.
+	 * @param x The x coordinate of the location.
+	 * @param z The z coordinate of the location.
+	 */
+	public double getAvgRainfall(int x, int z) {
+		return finalRainfall.GetValue(x / (scale * 128.0) + 0.05, 0.05, z / (scale * 128.0) + 0.05);
+	}
+
+	/**
+	 * Returns the raw temperature noise value [0-1] for a given location.
+	 * @param x The x coordinate of the location.
+	 * @param z The z coordinate of the location.
+	 */
+	public double getAvgTemperature(int x, int z) {
+		return finalTemp.GetValue(x / (scale * 128.0) + 0.05, 0.05, z / (scale * 128.0) + 0.05);
 	}
 }


### PR DESCRIPTION
Changes:
- Removed unused rainfall/temperature bits from the VanillaBiome class. They may return later if they actually start being used.
- Removed the checks on whether Vanilla is using all of the Vanilla biomes. Who are we kidding, anyway...
- Improved how rainfall is distributed. No more jungles right next to deserts! Silly Voronoi noise...
- Made beaches/swamps larger.
- Made continents larger/oceans smaller.
- Made biomes somewhat larger.
- Removed mountains for the time being (they are just too ugly using ridged noise).

Still to do:
- Re-implement mountains & small mountains with better noise.
- Implement hill biomes (Jungle Hills, Desert Hills, etc.).
- Add mushroom islands.
- Add rivers.
- Add lakes.
- Remove reliance on hard-coded ranges in the selector.
- Add the ability to recognize and select custom biomes.
- Remove those pesky 10-block wide biomes, if possible.

Signed-off-by: atheriel atherielx@gmail.com
