### PR TITLE
Change to getDrops in VanillaActionController

### DIFF
--- a/src/main/java/org/spout/vanilla/controller/living/creature/hostile/Blaze.java
+++ b/src/main/java/org/spout/vanilla/controller/living/creature/hostile/Blaze.java
@@ -29,13 +29,16 @@ package org.spout.vanilla.controller.living.creature.hostile;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.spout.api.Source;
 import org.spout.api.entity.type.ControllerType;
 import org.spout.api.entity.type.EmptyConstructorControllerType;
 import org.spout.api.inventory.ItemStack;
 
+import org.spout.vanilla.controller.VanillaActionController;
 import org.spout.vanilla.controller.VanillaControllerTypes;
 import org.spout.vanilla.controller.living.Creature;
 import org.spout.vanilla.controller.living.creature.Hostile;
+import org.spout.vanilla.controller.living.player.VanillaPlayer;
 import org.spout.vanilla.controller.source.HealthChangeReason;
 import org.spout.vanilla.material.VanillaMaterials;
 
@@ -54,7 +57,11 @@ public class Blaze extends Creature implements Hostile {
 	}
 
 	@Override
-	public Set<ItemStack> getDrops() {
+	public Set<ItemStack> getDrops(Source source, VanillaActionController lastDamager) {
+		if (lastDamager == null || !(lastDamager instanceof VanillaPlayer)) {
+			return super.getDrops(source, lastDamager);
+		}
+
 		Set<ItemStack> drops = new HashSet<ItemStack>();
 		int count = getRandom().nextInt(2);
 		if (count > 0) {

--- a/src/main/java/org/spout/vanilla/controller/living/creature/hostile/Creeper.java
+++ b/src/main/java/org/spout/vanilla/controller/living/creature/hostile/Creeper.java
@@ -29,13 +29,16 @@ package org.spout.vanilla.controller.living.creature.hostile;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.spout.api.Source;
 import org.spout.api.entity.type.ControllerType;
 import org.spout.api.entity.type.EmptyConstructorControllerType;
 import org.spout.api.inventory.ItemStack;
 
+import org.spout.vanilla.controller.VanillaActionController;
 import org.spout.vanilla.controller.VanillaControllerTypes;
 import org.spout.vanilla.controller.living.Creature;
 import org.spout.vanilla.controller.living.creature.Hostile;
+import org.spout.vanilla.controller.source.DamageCause;
 import org.spout.vanilla.controller.source.HealthChangeReason;
 import org.spout.vanilla.material.VanillaMaterials;
 
@@ -54,14 +57,16 @@ public class Creeper extends Creature implements Hostile {
 	}
 
 	@Override
-	public Set<ItemStack> getDrops() {
+	public Set<ItemStack> getDrops(Source source, VanillaActionController lastDamager) {
 		Set<ItemStack> drops = new HashSet<ItemStack>();
 		int count = getRandom().nextInt(3);
 		if (count > 0) {
 			drops.add(new ItemStack(VanillaMaterials.GUNPOWDER, count));
 		}
 
-		// TODO: Check if killed by skeleton for music disk
+		if (source.equals(DamageCause.Type.ARROW) && lastDamager != null && lastDamager instanceof Skeleton) {
+			drops.add(new ItemStack(VanillaMaterials.getMaterial((short) (VanillaMaterials.GOLD_MUSIC_DISC.getId() + getRandom().nextInt(11))), 1));
+		}
 		return drops;
 	}
 }

--- a/src/main/java/org/spout/vanilla/controller/living/creature/hostile/Enderdragon.java
+++ b/src/main/java/org/spout/vanilla/controller/living/creature/hostile/Enderdragon.java
@@ -29,10 +29,12 @@ package org.spout.vanilla.controller.living.creature.hostile;
 import java.util.Collections;
 import java.util.Set;
 
+import org.spout.api.Source;
 import org.spout.api.entity.type.ControllerType;
 import org.spout.api.entity.type.EmptyConstructorControllerType;
 import org.spout.api.inventory.ItemStack;
 
+import org.spout.vanilla.controller.VanillaActionController;
 import org.spout.vanilla.controller.VanillaControllerTypes;
 import org.spout.vanilla.controller.living.Creature;
 import org.spout.vanilla.controller.living.creature.Boss;
@@ -54,7 +56,7 @@ public class Enderdragon extends Creature implements Hostile, Boss {
 	}
 
 	@Override
-	public Set<ItemStack> getDrops() {
+	public Set<ItemStack> getDrops(Source source, VanillaActionController lastDamager) {
 		return Collections.emptySet();
 	}
 }

--- a/src/main/java/org/spout/vanilla/controller/living/creature/hostile/Ghast.java
+++ b/src/main/java/org/spout/vanilla/controller/living/creature/hostile/Ghast.java
@@ -29,10 +29,12 @@ package org.spout.vanilla.controller.living.creature.hostile;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.spout.api.Source;
 import org.spout.api.entity.type.ControllerType;
 import org.spout.api.entity.type.EmptyConstructorControllerType;
 import org.spout.api.inventory.ItemStack;
 
+import org.spout.vanilla.controller.VanillaActionController;
 import org.spout.vanilla.controller.VanillaControllerTypes;
 import org.spout.vanilla.controller.living.Creature;
 import org.spout.vanilla.controller.living.creature.Hostile;
@@ -54,7 +56,7 @@ public class Ghast extends Creature implements Hostile {
 	}
 
 	@Override
-	public Set<ItemStack> getDrops() {
+	public Set<ItemStack> getDrops(Source source, VanillaActionController lastDamager) {
 		Set<ItemStack> drops = new HashSet<ItemStack>();
 
 		int count = getRandom().nextInt(3);

--- a/src/main/java/org/spout/vanilla/controller/living/creature/hostile/Giant.java
+++ b/src/main/java/org/spout/vanilla/controller/living/creature/hostile/Giant.java
@@ -29,10 +29,12 @@ package org.spout.vanilla.controller.living.creature.hostile;
 import java.util.Collections;
 import java.util.Set;
 
+import org.spout.api.Source;
 import org.spout.api.entity.type.ControllerType;
 import org.spout.api.entity.type.EmptyConstructorControllerType;
 import org.spout.api.inventory.ItemStack;
 
+import org.spout.vanilla.controller.VanillaActionController;
 import org.spout.vanilla.controller.VanillaControllerTypes;
 import org.spout.vanilla.controller.living.Creature;
 import org.spout.vanilla.controller.living.creature.Hostile;
@@ -53,7 +55,7 @@ public class Giant extends Creature implements Hostile {
 	}
 
 	@Override
-	public Set<ItemStack> getDrops() {
+	public Set<ItemStack> getDrops(Source source, VanillaActionController lastDamager) {
 		return Collections.emptySet();
 	}
 }

--- a/src/main/java/org/spout/vanilla/controller/living/creature/hostile/MagmaSlime.java
+++ b/src/main/java/org/spout/vanilla/controller/living/creature/hostile/MagmaSlime.java
@@ -53,10 +53,11 @@ public class MagmaSlime extends Slime implements Hostile {
 		if (getSize() == 0) {
 			return drops;
 		}
-
-		int count = getRandom().nextInt(2);
-		if (count > 0) {
-			drops.add(new ItemStack(VanillaMaterials.MAGMA_CREAM, count));
+		if (getRandom().nextInt(100) < 25) {
+			int count = getRandom().nextInt(2);
+			if (count > 0) {
+				drops.add(new ItemStack(VanillaMaterials.MAGMA_CREAM, count));
+			}
 		}
 		return drops;
 	}

--- a/src/main/java/org/spout/vanilla/controller/living/creature/hostile/MagmaSlime.java
+++ b/src/main/java/org/spout/vanilla/controller/living/creature/hostile/MagmaSlime.java
@@ -29,10 +29,12 @@ package org.spout.vanilla.controller.living.creature.hostile;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.spout.api.Source;
 import org.spout.api.entity.type.ControllerType;
 import org.spout.api.entity.type.EmptyConstructorControllerType;
 import org.spout.api.inventory.ItemStack;
 
+import org.spout.vanilla.controller.VanillaActionController;
 import org.spout.vanilla.controller.VanillaControllerTypes;
 import org.spout.vanilla.controller.living.creature.Hostile;
 import org.spout.vanilla.material.VanillaMaterials;
@@ -45,7 +47,7 @@ public class MagmaSlime extends Slime implements Hostile {
 	}
 
 	@Override
-	public Set<ItemStack> getDrops() {
+	public Set<ItemStack> getDrops(Source source, VanillaActionController lastDamager) {
 		Set<ItemStack> drops = new HashSet<ItemStack>();
 
 		if (getSize() == 0) {

--- a/src/main/java/org/spout/vanilla/controller/living/creature/hostile/Skeleton.java
+++ b/src/main/java/org/spout/vanilla/controller/living/creature/hostile/Skeleton.java
@@ -29,15 +29,20 @@ package org.spout.vanilla.controller.living.creature.hostile;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.spout.api.Source;
 import org.spout.api.entity.type.ControllerType;
 import org.spout.api.entity.type.EmptyConstructorControllerType;
 import org.spout.api.inventory.ItemStack;
 
+import org.spout.vanilla.controller.VanillaActionController;
 import org.spout.vanilla.controller.VanillaControllerTypes;
 import org.spout.vanilla.controller.living.Creature;
 import org.spout.vanilla.controller.living.creature.Hostile;
+import org.spout.vanilla.controller.living.player.VanillaPlayer;
 import org.spout.vanilla.controller.source.HealthChangeReason;
+import org.spout.vanilla.enchantment.Enchantments;
 import org.spout.vanilla.material.VanillaMaterials;
+import org.spout.vanilla.util.EnchantmentUtil;
 
 public class Skeleton extends Creature implements Hostile {
 	public static final ControllerType TYPE = new EmptyConstructorControllerType(Skeleton.class, "Skeleton");
@@ -54,7 +59,7 @@ public class Skeleton extends Creature implements Hostile {
 	}
 
 	@Override
-	public Set<ItemStack> getDrops() {
+	public Set<ItemStack> getDrops(Source source, VanillaActionController lastDamager) {
 		Set<ItemStack> drops = new HashSet<ItemStack>();
 
 		int count = getRandom().nextInt(3);
@@ -67,9 +72,14 @@ public class Skeleton extends Creature implements Hostile {
 			drops.add(new ItemStack(VanillaMaterials.BONE, count));
 		}
 
-		// TODO: Enchantments
-		if (getRandom().nextInt(32) == 0) {
-			drops.add(new ItemStack(VanillaMaterials.BOW, 1));
+		if (lastDamager != null && lastDamager instanceof VanillaPlayer) {
+			if (getRandom().nextInt(32) == 0) {
+				ItemStack bow = new ItemStack(VanillaMaterials.BOW, 1);
+				if (getRandom().nextInt(5) == 0) {
+					EnchantmentUtil.addEnchantment(bow, Enchantments.POWER);
+				}
+				drops.add(bow);
+			}
 		}
 
 		return drops;

--- a/src/main/java/org/spout/vanilla/controller/living/creature/hostile/Slime.java
+++ b/src/main/java/org/spout/vanilla/controller/living/creature/hostile/Slime.java
@@ -29,10 +29,12 @@ package org.spout.vanilla.controller.living.creature.hostile;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.spout.api.Source;
 import org.spout.api.entity.type.ControllerType;
 import org.spout.api.entity.type.EmptyConstructorControllerType;
 import org.spout.api.inventory.ItemStack;
 
+import org.spout.vanilla.controller.VanillaActionController;
 import org.spout.vanilla.controller.VanillaControllerType;
 import org.spout.vanilla.controller.VanillaControllerTypes;
 import org.spout.vanilla.controller.living.Creature;
@@ -68,7 +70,7 @@ public class Slime extends Creature implements Hostile {
 	}
 
 	@Override
-	public Set<ItemStack> getDrops() {
+	public Set<ItemStack> getDrops(Source source, VanillaActionController lastDamager) {
 		Set<ItemStack> drops = new HashSet<ItemStack>();
 		if (getSize() == 0) {
 			return drops;

--- a/src/main/java/org/spout/vanilla/controller/living/creature/hostile/Spider.java
+++ b/src/main/java/org/spout/vanilla/controller/living/creature/hostile/Spider.java
@@ -70,7 +70,7 @@ public class Spider extends Creature implements Hostile {
 			drops.add(new ItemStack(VanillaMaterials.STRING, count));
 		}
 
-		if (lastDamager != null && lastDamager instanceof VanillaPlayer) {
+		if (lastDamager != null && lastDamager instanceof VanillaPlayer && getRandom().nextInt(100) < 33) {
 			count = getRandom().nextInt(2);
 			if (count > 0) {
 				drops.add(new ItemStack(VanillaMaterials.SPIDER_EYE, count));

--- a/src/main/java/org/spout/vanilla/controller/living/creature/hostile/Spider.java
+++ b/src/main/java/org/spout/vanilla/controller/living/creature/hostile/Spider.java
@@ -29,14 +29,17 @@ package org.spout.vanilla.controller.living.creature.hostile;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.spout.api.Source;
 import org.spout.api.entity.type.ControllerType;
 import org.spout.api.entity.type.EmptyConstructorControllerType;
 import org.spout.api.inventory.ItemStack;
 
+import org.spout.vanilla.controller.VanillaActionController;
 import org.spout.vanilla.controller.VanillaControllerType;
 import org.spout.vanilla.controller.VanillaControllerTypes;
 import org.spout.vanilla.controller.living.Creature;
 import org.spout.vanilla.controller.living.creature.Hostile;
+import org.spout.vanilla.controller.living.player.VanillaPlayer;
 import org.spout.vanilla.controller.source.HealthChangeReason;
 import org.spout.vanilla.material.VanillaMaterials;
 
@@ -59,7 +62,7 @@ public class Spider extends Creature implements Hostile {
 	}
 
 	@Override
-	public Set<ItemStack> getDrops() {
+	public Set<ItemStack> getDrops(Source source, VanillaActionController lastDamager) {
 		Set<ItemStack> drops = new HashSet<ItemStack>();
 
 		int count = getRandom().nextInt(3);
@@ -67,9 +70,11 @@ public class Spider extends Creature implements Hostile {
 			drops.add(new ItemStack(VanillaMaterials.STRING, count));
 		}
 
-		count = getRandom().nextInt(2);
-		if (count > 0) {
-			drops.add(new ItemStack(VanillaMaterials.SPIDER_EYE, count));
+		if (lastDamager != null && lastDamager instanceof VanillaPlayer) {
+			count = getRandom().nextInt(2);
+			if (count > 0) {
+				drops.add(new ItemStack(VanillaMaterials.SPIDER_EYE, count));
+			}
 		}
 
 		return drops;

--- a/src/main/java/org/spout/vanilla/controller/living/creature/hostile/Zombie.java
+++ b/src/main/java/org/spout/vanilla/controller/living/creature/hostile/Zombie.java
@@ -29,14 +29,17 @@ package org.spout.vanilla.controller.living.creature.hostile;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.spout.api.Source;
 import org.spout.api.entity.type.ControllerType;
 import org.spout.api.entity.type.EmptyConstructorControllerType;
 import org.spout.api.inventory.ItemStack;
 
+import org.spout.vanilla.controller.VanillaActionController;
 import org.spout.vanilla.controller.VanillaControllerType;
 import org.spout.vanilla.controller.VanillaControllerTypes;
 import org.spout.vanilla.controller.living.Creature;
 import org.spout.vanilla.controller.living.creature.Hostile;
+import org.spout.vanilla.controller.living.player.VanillaPlayer;
 import org.spout.vanilla.controller.source.HealthChangeReason;
 import org.spout.vanilla.material.VanillaMaterials;
 
@@ -59,7 +62,7 @@ public class Zombie extends Creature implements Hostile {
 	}
 
 	@Override
-	public Set<ItemStack> getDrops() {
+	public Set<ItemStack> getDrops(Source source, VanillaActionController lastDamager) {
 		Set<ItemStack> drops = new HashSet<ItemStack>();
 
 		int count = getRandom().nextInt(3);
@@ -67,21 +70,22 @@ public class Zombie extends Creature implements Hostile {
 			drops.add(new ItemStack(VanillaMaterials.ROTTEN_FLESH, count));
 		}
 
-		if (getRandom().nextInt(25) == 0) {
-			drops.add(new ItemStack(VanillaMaterials.IRON_INGOT, 1));
-		}
+		if (lastDamager != null && lastDamager instanceof VanillaPlayer) {
+			if (getRandom().nextInt(25) == 0) {
+				drops.add(new ItemStack(VanillaMaterials.IRON_INGOT, 1));
+			}
 
-		// TODO: Enchantments
-		if (getRandom().nextInt(50) == 0) {
-			drops.add(new ItemStack(VanillaMaterials.IRON_HELMET, 1));
-		}
+			if (getRandom().nextInt(50) == 0) {
+				drops.add(new ItemStack(VanillaMaterials.IRON_HELMET, 1));
+			}
 
-		if (getRandom().nextInt(75) == 0) {
-			drops.add(new ItemStack(VanillaMaterials.IRON_SPADE, 1));
-		}
+			if (getRandom().nextInt(75) == 0) {
+				drops.add(new ItemStack(VanillaMaterials.IRON_SPADE, 1));
+			}
 
-		if (getRandom().nextInt(100) == 0) {
-			drops.add(new ItemStack(VanillaMaterials.IRON_SWORD, 1));
+			if (getRandom().nextInt(100) == 0) {
+				drops.add(new ItemStack(VanillaMaterials.IRON_SWORD, 1));
+			}
 		}
 
 		return drops;

--- a/src/main/java/org/spout/vanilla/controller/living/creature/neutral/Enderman.java
+++ b/src/main/java/org/spout/vanilla/controller/living/creature/neutral/Enderman.java
@@ -29,10 +29,12 @@ package org.spout.vanilla.controller.living.creature.neutral;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.spout.api.Source;
 import org.spout.api.entity.type.ControllerType;
 import org.spout.api.entity.type.EmptyConstructorControllerType;
 import org.spout.api.inventory.ItemStack;
 
+import org.spout.vanilla.controller.VanillaActionController;
 import org.spout.vanilla.controller.VanillaControllerTypes;
 import org.spout.vanilla.controller.living.Creature;
 import org.spout.vanilla.controller.living.creature.Neutral;
@@ -69,16 +71,11 @@ public class Enderman extends Creature implements Neutral {
 	}
 
 	@Override
-	public Set<ItemStack> getDrops() {
+	public Set<ItemStack> getDrops(Source source, VanillaActionController lastDamager) {
 		Set<ItemStack> drops = new HashSet<ItemStack>();
 		int count = getRandom().nextInt(2);
 		if (count > 0) {
 			drops.add(new ItemStack(VanillaMaterials.ENDER_PEARL, count));
-		}
-
-		if (heldItem != null && !heldItem.getMaterial().equals(VanillaMaterials.AIR)) {
-			drops.add(heldItem);
-			setHeldItem(null);
 		}
 
 		return drops;

--- a/src/main/java/org/spout/vanilla/controller/living/creature/neutral/PigZombie.java
+++ b/src/main/java/org/spout/vanilla/controller/living/creature/neutral/PigZombie.java
@@ -29,13 +29,16 @@ package org.spout.vanilla.controller.living.creature.neutral;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.spout.api.Source;
 import org.spout.api.entity.type.ControllerType;
 import org.spout.api.entity.type.EmptyConstructorControllerType;
 import org.spout.api.inventory.ItemStack;
 
+import org.spout.vanilla.controller.VanillaActionController;
 import org.spout.vanilla.controller.VanillaControllerTypes;
 import org.spout.vanilla.controller.living.creature.Neutral;
 import org.spout.vanilla.controller.living.creature.hostile.Zombie;
+import org.spout.vanilla.controller.living.player.VanillaPlayer;
 import org.spout.vanilla.controller.source.HealthChangeReason;
 import org.spout.vanilla.material.VanillaMaterials;
 
@@ -54,7 +57,7 @@ public class PigZombie extends Zombie implements Neutral {
 	}
 
 	@Override
-	public Set<ItemStack> getDrops() {
+	public Set<ItemStack> getDrops(Source source, VanillaActionController lastDamager) {
 		Set<ItemStack> drops = new HashSet<ItemStack>();
 		int count = getRandom().nextInt(2);
 		if (count > 0) {
@@ -66,16 +69,19 @@ public class PigZombie extends Zombie implements Neutral {
 			drops.add(new ItemStack(VanillaMaterials.GOLD_NUGGET, count));
 		}
 
-		if (getRandom().nextInt(25) == 0) {
-			drops.add(new ItemStack(VanillaMaterials.GOLD_INGOT, 1));
-		}
+		if (lastDamager != null && lastDamager instanceof VanillaPlayer) {
+			// TODO enchantments
+			if (getRandom().nextInt(25) == 0) {
+				drops.add(new ItemStack(VanillaMaterials.GOLD_INGOT, 1));
+			}
 
-		if (getRandom().nextInt(50) == 0) {
-			drops.add(new ItemStack(VanillaMaterials.GOLD_SWORD, 1));
-		}
+			if (getRandom().nextInt(50) == 0) {
+				drops.add(new ItemStack(VanillaMaterials.GOLD_SWORD, 1));
+			}
 
-		if (getRandom().nextInt(75) == 0) {
-			drops.add(new ItemStack(VanillaMaterials.GOLD_HELMET, 1));
+			if (getRandom().nextInt(75) == 0) {
+				drops.add(new ItemStack(VanillaMaterials.GOLD_HELMET, 1));
+			}
 		}
 
 		return drops;

--- a/src/main/java/org/spout/vanilla/controller/living/creature/neutral/Wolf.java
+++ b/src/main/java/org/spout/vanilla/controller/living/creature/neutral/Wolf.java
@@ -26,12 +26,9 @@
  */
 package org.spout.vanilla.controller.living.creature.neutral;
 
-import java.util.Set;
-
 import org.spout.api.entity.Controller;
 import org.spout.api.entity.type.ControllerType;
 import org.spout.api.entity.type.EmptyConstructorControllerType;
-import org.spout.api.inventory.ItemStack;
 
 import org.spout.vanilla.controller.VanillaControllerTypes;
 import org.spout.vanilla.controller.living.Creature;
@@ -49,7 +46,7 @@ public class Wolf extends Creature implements Tameable, Neutral {
 
 	@Override
 	public void onAttached() {
-		//master = data().get("controllingentity", master);
+		// master = data().get("controllingentity", master);
 		if (master != null) {
 			setHealth(20, new HealthChangeReason(HealthChangeReason.Type.SPAWN));
 			setMaxHealth(20);
@@ -64,7 +61,7 @@ public class Wolf extends Creature implements Tameable, Neutral {
 	@Override
 	public void onSave() {
 		super.onSave();
-		//data().put("controllingentity", master);
+		// data().put("controllingentity", master);
 	}
 
 	@Override
@@ -76,10 +73,4 @@ public class Wolf extends Creature implements Tameable, Neutral {
 	public boolean isControlled() {
 		return master != null;
 	}
-
-	@Override
-	public Set<ItemStack> getDrops() {
-		return null;
-	}
 }
-

--- a/src/main/java/org/spout/vanilla/controller/living/creature/passive/Chicken.java
+++ b/src/main/java/org/spout/vanilla/controller/living/creature/passive/Chicken.java
@@ -29,13 +29,16 @@ package org.spout.vanilla.controller.living.creature.passive;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.spout.api.Source;
 import org.spout.api.entity.type.ControllerType;
 import org.spout.api.entity.type.EmptyConstructorControllerType;
 import org.spout.api.inventory.ItemStack;
 
+import org.spout.vanilla.controller.VanillaActionController;
 import org.spout.vanilla.controller.VanillaControllerTypes;
 import org.spout.vanilla.controller.living.Creature;
 import org.spout.vanilla.controller.living.creature.Passive;
+import org.spout.vanilla.controller.source.DamageCause;
 import org.spout.vanilla.controller.source.HealthChangeReason;
 import org.spout.vanilla.material.VanillaMaterials;
 
@@ -54,17 +57,20 @@ public class Chicken extends Creature implements Passive {
 	}
 
 	@Override
-	public Set<ItemStack> getDrops() {
+	public Set<ItemStack> getDrops(Source source, VanillaActionController lastDamager) {
 		Set<ItemStack> drops = new HashSet<ItemStack>();
 		int count = getRandom().nextInt(3);
 		if (count > 0) {
 			drops.add(new ItemStack(VanillaMaterials.FEATHER, count));
 		}
 
-		// TODO: Check if killed by fire
 		count = getRandom().nextInt(2);
 		if (count > 0) {
-			drops.add(new ItemStack(VanillaMaterials.RAW_CHICKEN, count));
+			if (source.equals(DamageCause.Type.BURN)) {
+				drops.add(new ItemStack(VanillaMaterials.COOKED_CHICKEN, count));
+			} else {
+				drops.add(new ItemStack(VanillaMaterials.RAW_CHICKEN, count));
+			}
 		}
 
 		return drops;

--- a/src/main/java/org/spout/vanilla/controller/living/creature/passive/Cow.java
+++ b/src/main/java/org/spout/vanilla/controller/living/creature/passive/Cow.java
@@ -29,14 +29,17 @@ package org.spout.vanilla.controller.living.creature.passive;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.spout.api.Source;
 import org.spout.api.entity.type.ControllerType;
 import org.spout.api.entity.type.EmptyConstructorControllerType;
 import org.spout.api.inventory.ItemStack;
 
+import org.spout.vanilla.controller.VanillaActionController;
 import org.spout.vanilla.controller.VanillaControllerType;
 import org.spout.vanilla.controller.VanillaControllerTypes;
 import org.spout.vanilla.controller.living.Creature;
 import org.spout.vanilla.controller.living.creature.Passive;
+import org.spout.vanilla.controller.source.DamageCause;
 import org.spout.vanilla.controller.source.HealthChangeReason;
 import org.spout.vanilla.material.VanillaMaterials;
 
@@ -59,7 +62,7 @@ public class Cow extends Creature implements Passive {
 	}
 
 	@Override
-	public Set<ItemStack> getDrops() {
+	public Set<ItemStack> getDrops(Source source, VanillaActionController lastDamager) {
 		Set<ItemStack> drops = new HashSet<ItemStack>();
 
 		int count = getRandom().nextInt(3);
@@ -69,7 +72,11 @@ public class Cow extends Creature implements Passive {
 
 		count = getRandom().nextInt(2) + 1;
 		if (count > 0) {
-			drops.add(new ItemStack(VanillaMaterials.RAW_BEEF, count));
+			if (source.equals(DamageCause.Type.BURN)) {
+				drops.add(new ItemStack(VanillaMaterials.STEAK, count));
+			} else {
+				drops.add(new ItemStack(VanillaMaterials.RAW_BEEF, count));
+			}
 		}
 
 		return drops;

--- a/src/main/java/org/spout/vanilla/controller/living/creature/passive/Ocelot.java
+++ b/src/main/java/org/spout/vanilla/controller/living/creature/passive/Ocelot.java
@@ -26,13 +26,9 @@
  */
 package org.spout.vanilla.controller.living.creature.passive;
 
-import java.util.HashSet;
-import java.util.Set;
-
 import org.spout.api.entity.Controller;
 import org.spout.api.entity.type.ControllerType;
 import org.spout.api.entity.type.EmptyConstructorControllerType;
-import org.spout.api.inventory.ItemStack;
 
 import org.spout.vanilla.controller.VanillaControllerTypes;
 import org.spout.vanilla.controller.living.Creature;
@@ -50,8 +46,8 @@ public class Ocelot extends Creature implements Tameable, Passive {
 
 	@Override
 	public void onAttached() {
-		//TODO Check these values...
-		//master = data().get("controllingentity", master);
+		// TODO Check these values...
+		// master = data().get("controllingentity", master);
 		if (master != null) {
 			setHealth(20, new HealthChangeReason(HealthChangeReason.Type.SPAWN));
 			setMaxHealth(20);
@@ -66,13 +62,7 @@ public class Ocelot extends Creature implements Tameable, Passive {
 	@Override
 	public void onSave() {
 		super.onSave();
-		//data().put("controllingentity", master);
-	}
-
-	@Override
-	public Set<ItemStack> getDrops() {
-		Set<ItemStack> drops = new HashSet<ItemStack>();
-		return drops;
+		// data().put("controllingentity", master);
 	}
 
 	@Override

--- a/src/main/java/org/spout/vanilla/controller/living/creature/passive/Pig.java
+++ b/src/main/java/org/spout/vanilla/controller/living/creature/passive/Pig.java
@@ -29,13 +29,16 @@ package org.spout.vanilla.controller.living.creature.passive;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.spout.api.Source;
 import org.spout.api.entity.type.ControllerType;
 import org.spout.api.entity.type.EmptyConstructorControllerType;
 import org.spout.api.inventory.ItemStack;
 
+import org.spout.vanilla.controller.VanillaActionController;
 import org.spout.vanilla.controller.VanillaControllerTypes;
 import org.spout.vanilla.controller.living.Creature;
 import org.spout.vanilla.controller.living.creature.Passive;
+import org.spout.vanilla.controller.source.DamageCause;
 import org.spout.vanilla.controller.source.HealthChangeReason;
 import org.spout.vanilla.material.VanillaMaterials;
 
@@ -54,12 +57,15 @@ public class Pig extends Creature implements Passive {
 	}
 
 	@Override
-	public Set<ItemStack> getDrops() {
+	public Set<ItemStack> getDrops(Source source, VanillaActionController lastDamager) {
 		Set<ItemStack> drops = new HashSet<ItemStack>();
-		// TODO: Check if killed by fire
 		int count = getRandom().nextInt(3);
 		if (count > 0) {
-			drops.add(new ItemStack(VanillaMaterials.RAW_PORKCHOP, count));
+			if (source.equals(DamageCause.Type.BURN)) {
+				drops.add(new ItemStack(VanillaMaterials.COOKED_PORKCHOP, count));
+			} else {
+				drops.add(new ItemStack(VanillaMaterials.RAW_PORKCHOP, count));
+			}
 		}
 
 		return drops;

--- a/src/main/java/org/spout/vanilla/controller/living/creature/passive/Sheep.java
+++ b/src/main/java/org/spout/vanilla/controller/living/creature/passive/Sheep.java
@@ -29,13 +29,16 @@ package org.spout.vanilla.controller.living.creature.passive;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.spout.api.Source;
 import org.spout.api.entity.type.ControllerType;
 import org.spout.api.entity.type.EmptyConstructorControllerType;
 import org.spout.api.inventory.ItemStack;
 
+import org.spout.vanilla.controller.VanillaActionController;
 import org.spout.vanilla.controller.VanillaControllerTypes;
 import org.spout.vanilla.controller.living.Creature;
 import org.spout.vanilla.controller.living.creature.Passive;
+import org.spout.vanilla.controller.source.DamageCause;
 import org.spout.vanilla.controller.source.HealthChangeReason;
 import org.spout.vanilla.material.VanillaMaterials;
 import org.spout.vanilla.material.block.solid.Wool;
@@ -98,10 +101,14 @@ public class Sheep extends Creature implements Passive {
 	}
 
 	@Override
-	public Set<ItemStack> getDrops() {
+	public Set<ItemStack> getDrops(Source source, VanillaActionController lastDamager) {
 		Set<ItemStack> drops = new HashSet<ItemStack>();
 		if (!isSheared()) {
-			drops.add(new ItemStack(VanillaMaterials.WOOL.getSubMaterial(((Number) data().get("SheepColor")).shortValue()), 1));
+			if (source.equals(DamageCause.Type.BURN)) {
+				drops.add(new ItemStack(Wool.GRAY, 1));
+			} else {
+				drops.add(new ItemStack(VanillaMaterials.WOOL.getSubMaterial(((Number) data().get("SheepColor")).shortValue()), 1));
+			}
 		}
 
 		return drops;

--- a/src/main/java/org/spout/vanilla/controller/living/creature/passive/Squid.java
+++ b/src/main/java/org/spout/vanilla/controller/living/creature/passive/Squid.java
@@ -29,10 +29,12 @@ package org.spout.vanilla.controller.living.creature.passive;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.spout.api.Source;
 import org.spout.api.entity.type.ControllerType;
 import org.spout.api.entity.type.EmptyConstructorControllerType;
 import org.spout.api.inventory.ItemStack;
 
+import org.spout.vanilla.controller.VanillaActionController;
 import org.spout.vanilla.controller.VanillaControllerTypes;
 import org.spout.vanilla.controller.living.Creature;
 import org.spout.vanilla.controller.living.creature.Passive;
@@ -54,9 +56,9 @@ public class Squid extends Creature implements Passive {
 	}
 
 	@Override
-	public Set<ItemStack> getDrops() {
+	public Set<ItemStack> getDrops(Source source, VanillaActionController lastDamager) {
 		Set<ItemStack> drops = new HashSet<ItemStack>();
-		int count = getRandom().nextInt(4);
+		int count = getRandom().nextInt(3) + 1;
 		if (count > 0) {
 			drops.add(new ItemStack(Dye.INK_SAC, count));
 		}

--- a/src/main/java/org/spout/vanilla/controller/living/creature/passive/Villager.java
+++ b/src/main/java/org/spout/vanilla/controller/living/creature/passive/Villager.java
@@ -26,12 +26,8 @@
  */
 package org.spout.vanilla.controller.living.creature.passive;
 
-import java.util.Collections;
-import java.util.Set;
-
 import org.spout.api.entity.type.ControllerType;
 import org.spout.api.entity.type.EmptyConstructorControllerType;
-import org.spout.api.inventory.ItemStack;
 
 import org.spout.vanilla.controller.VanillaControllerTypes;
 import org.spout.vanilla.controller.living.Creature;
@@ -50,10 +46,5 @@ public class Villager extends Creature implements Passive {
 		setHealth(20, new HealthChangeReason(HealthChangeReason.Type.SPAWN));
 		setMaxHealth(20);
 		super.onAttached();
-	}
-
-	@Override
-	public Set<ItemStack> getDrops() {
-		return Collections.emptySet();
 	}
 }

--- a/src/main/java/org/spout/vanilla/controller/living/creature/util/IronGolem.java
+++ b/src/main/java/org/spout/vanilla/controller/living/creature/util/IronGolem.java
@@ -26,13 +26,20 @@
  */
 package org.spout.vanilla.controller.living.creature.util;
 
+import java.util.HashSet;
+import java.util.Set;
+
+import org.spout.api.Source;
 import org.spout.api.entity.type.ControllerType;
 import org.spout.api.entity.type.EmptyConstructorControllerType;
+import org.spout.api.inventory.ItemStack;
 
+import org.spout.vanilla.controller.VanillaActionController;
 import org.spout.vanilla.controller.VanillaControllerTypes;
 import org.spout.vanilla.controller.living.Creature;
 import org.spout.vanilla.controller.living.creature.Utility;
 import org.spout.vanilla.controller.source.HealthChangeReason;
+import org.spout.vanilla.material.VanillaMaterials;
 
 public class IronGolem extends Creature implements Utility {
 	public static final ControllerType TYPE = new EmptyConstructorControllerType(IronGolem.class, "Iron Golem");
@@ -46,5 +53,20 @@ public class IronGolem extends Creature implements Utility {
 		setHealth(100, new HealthChangeReason(HealthChangeReason.Type.SPAWN));
 		setMaxHealth(100);
 		super.onAttached();
+	}
+
+	@Override
+	public Set<ItemStack> getDrops(Source source, VanillaActionController lastDamager) {
+		Set<ItemStack> drops = new HashSet<ItemStack>();
+		int count = getRandom().nextInt(3) + 3;
+		if (count > 0) {
+			drops.add(new ItemStack(VanillaMaterials.IRON_INGOT, count));
+		}
+
+		count = getRandom().nextInt(3);
+		if (count > 0) {
+			drops.add(new ItemStack(VanillaMaterials.ROSE, count));
+		}
+		return drops;
 	}
 }

--- a/src/main/java/org/spout/vanilla/controller/living/creature/util/SnowGolem.java
+++ b/src/main/java/org/spout/vanilla/controller/living/creature/util/SnowGolem.java
@@ -26,13 +26,20 @@
  */
 package org.spout.vanilla.controller.living.creature.util;
 
+import java.util.HashSet;
+import java.util.Set;
+
+import org.spout.api.Source;
 import org.spout.api.entity.type.ControllerType;
 import org.spout.api.entity.type.EmptyConstructorControllerType;
+import org.spout.api.inventory.ItemStack;
 
+import org.spout.vanilla.controller.VanillaActionController;
 import org.spout.vanilla.controller.VanillaControllerTypes;
 import org.spout.vanilla.controller.living.Creature;
 import org.spout.vanilla.controller.living.creature.Passive;
 import org.spout.vanilla.controller.source.HealthChangeReason;
+import org.spout.vanilla.material.VanillaMaterials;
 
 public class SnowGolem extends Creature implements Passive {
 	public static final ControllerType TYPE = new EmptyConstructorControllerType(SnowGolem.class, "Snow Golem");
@@ -46,5 +53,16 @@ public class SnowGolem extends Creature implements Passive {
 		setHealth(6, new HealthChangeReason(HealthChangeReason.Type.SPAWN));
 		setMaxHealth(6);
 		super.onAttached();
+	}
+
+	@Override
+	public Set<ItemStack> getDrops(Source source, VanillaActionController lastDamager) {
+		Set<ItemStack> drops = new HashSet<ItemStack>();
+		int count = getRandom().nextInt(16);
+		if (count > 0) {
+			drops.add(new ItemStack(VanillaMaterials.SNOWBALL, count));
+		}
+
+		return drops;
 	}
 }

--- a/src/main/java/org/spout/vanilla/controller/living/player/VanillaPlayer.java
+++ b/src/main/java/org/spout/vanilla/controller/living/player/VanillaPlayer.java
@@ -30,6 +30,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.spout.api.Source;
 import org.spout.api.Spout;
 import org.spout.api.entity.Entity;
 import org.spout.api.entity.PlayerController;
@@ -43,9 +44,11 @@ import org.spout.api.math.Vector3;
 import org.spout.api.player.Player;
 
 import org.spout.vanilla.configuration.VanillaConfiguration;
+import org.spout.vanilla.controller.VanillaActionController;
 import org.spout.vanilla.controller.VanillaControllerTypes;
 import org.spout.vanilla.controller.living.Human;
 import org.spout.vanilla.controller.object.moving.Item;
+import org.spout.vanilla.controller.source.DamageCause;
 import org.spout.vanilla.controller.source.HealthChangeReason;
 import org.spout.vanilla.inventory.Window;
 import org.spout.vanilla.inventory.player.PlayerInventory;
@@ -203,7 +206,7 @@ public class VanillaPlayer extends Human implements PlayerController {
 		boolean changed = false;
 		if (hunger <= 0 && health > 0) {
 			health = (short) Math.max(health - 1, 0);
-			setHealth(health, new HealthChangeReason(HealthChangeReason.Type.STARVE));
+			setHealth(health, new DamageCause(DamageCause.Type.STARVE));
 			changed = true;
 		} else if (hunger >= 18 && health < 20) {
 			health = (short) Math.min(health + 1, 20);
@@ -270,7 +273,7 @@ public class VanillaPlayer extends Human implements PlayerController {
 	}
 
 	@Override
-	public Set<ItemStack> getDrops() {
+	public Set<ItemStack> getDrops(Source source, VanillaActionController lastDamager) {
 		Set<ItemStack> drops = new HashSet<ItemStack>();
 		ItemStack[] contents = this.getInventory().getContents();
 		drops.addAll(Arrays.asList(contents));

--- a/src/main/java/org/spout/vanilla/controller/source/DamageCause.java
+++ b/src/main/java/org/spout/vanilla/controller/source/DamageCause.java
@@ -24,38 +24,59 @@
  * License and see <http://www.spout.org/SpoutDevLicenseV1.txt> for the full license,
  * including the MIT license.
  */
-package org.spout.vanilla.controller.living.creature.hostile;
+package org.spout.vanilla.controller.source;
 
-import java.util.Collections;
-import java.util.Set;
+/**
+ * Represents a source of damage.
+ */
+public class DamageCause extends Reason {
+	private final Type type;
 
-import org.spout.api.Source;
-import org.spout.api.entity.type.ControllerType;
-import org.spout.api.entity.type.EmptyConstructorControllerType;
-import org.spout.api.inventory.ItemStack;
+	public DamageCause(Type type) {
+		this.type = type;
+	}
 
-import org.spout.vanilla.controller.VanillaActionController;
-import org.spout.vanilla.controller.VanillaControllerTypes;
-import org.spout.vanilla.controller.living.Creature;
-import org.spout.vanilla.controller.living.creature.Hostile;
-import org.spout.vanilla.controller.source.HealthChangeReason;
+	/**
+	 * Returns the type of damage.
+	 * @return Damage type
+	 */
+	public Type getType() {
+		return type;
+	}
 
-public class Silverfish extends Creature implements Hostile {
-	public static final ControllerType TYPE = new EmptyConstructorControllerType(Silverfish.class, "Silverfish");
-
-	public Silverfish() {
-		super(VanillaControllerTypes.SILVERFISH);
+	public enum Type {
+		/**
+		 * Damaged by an arrow.
+		 */
+		ARROW,
+		/**
+		 * Damaged by another entity attacking.
+		 */
+		ATTACK,
+		/**
+		 * Damaged by fire.
+		 */
+		BURN,
+		/**
+		 * Damaged by touching cactus.
+		 */
+		CACTUS,
+		/**
+		 * Damaged by an explosion.
+		 */
+		EXPLOSION,
+		/**
+		 * Damaged due to starvation.
+		 */
+		STARVE,
+		/**
+		 * Damaged by an unknown source.
+		 */
+		UNKNOWN;
 	}
 
 	@Override
-	public void onAttached() {
-		setHealth(8, new HealthChangeReason(HealthChangeReason.Type.SPAWN));
-		setMaxHealth(8);
-		super.onAttached();
-	}
-
-	@Override
-	public Set<ItemStack> getDrops(Source source, VanillaActionController lastDamager) {
-		return Collections.emptySet();
+	public boolean equals(Object obj) {
+		return obj.equals(type);
 	}
 }

--- a/src/main/java/org/spout/vanilla/controller/source/HealthChangeReason.java
+++ b/src/main/java/org/spout/vanilla/controller/source/HealthChangeReason.java
@@ -49,6 +49,15 @@ public class HealthChangeReason extends Reason {
 	 */
 	public enum Type {
 		/**
+		 * Health changed due to the execution of a command.
+		 */
+		COMMAND,
+		/**
+		 * Health changed due to being damaged.
+		 * @see {@link DamageCause}
+		 */
+		DAMAGE,
+		/**
 		 * Health changed due to regeneration cycle.
 		 */
 		REGENERATION,
@@ -56,14 +65,6 @@ public class HealthChangeReason extends Reason {
 		 * Health changed due to the entity spawning.
 		 */
 		SPAWN,
-		/**
-		 * Health changed due to starvation.
-		 */
-		STARVE,
-		/**
-		 * Health changed due to the execution of a command.
-		 */
-		COMMAND,
 		/**
 		 * Health changed due to some unknown reason.
 		 */

--- a/src/main/java/org/spout/vanilla/material/VanillaMaterials.java
+++ b/src/main/java/org/spout/vanilla/material/VanillaMaterials.java
@@ -192,9 +192,9 @@ import org.spout.vanilla.material.item.misc.Sign;
 import org.spout.vanilla.material.item.misc.SpawnEgg;
 import org.spout.vanilla.material.item.misc.Stick;
 import org.spout.vanilla.material.item.misc.StorageMinecartItem;
+import org.spout.vanilla.material.item.tool.FishingRod;
 import org.spout.vanilla.material.item.tool.FlintAndSteel;
 import org.spout.vanilla.material.item.tool.Hoe;
-import org.spout.vanilla.material.item.tool.Tool;
 import org.spout.vanilla.material.item.tool.diamond.DiamondAxe;
 import org.spout.vanilla.material.item.tool.diamond.DiamondPickaxe;
 import org.spout.vanilla.material.item.tool.diamond.DiamondSpade;
@@ -415,7 +415,7 @@ public final class VanillaMaterials {
 	public static final FlintAndSteel FLINT_AND_STEEL = new FlintAndSteel("Flint and Steel", 259, (short) 64);
 	public static final Bow BOW = new Bow("Bow", 261, (short) 385);
 	public static final VanillaItemMaterial ARROW = new VanillaItemMaterial("Arrow", 262);
-	public static final Tool FISHING_ROD = new Tool("Fishing Rod", 346, (short) 65);
+	public static final FishingRod FISHING_ROD = new FishingRod("Fishing Rod", 346, (short) 65);
 	//== Buckets=
 	public static final EmptyContainer BUCKET = new EmptyContainer("Bucket", 325);
 	public static final FullContainer WATER_BUCKET = new FullContainer("Water Bucket", 326, WATER, BUCKET);

--- a/src/main/java/org/spout/vanilla/material/item/Armor.java
+++ b/src/main/java/org/spout/vanilla/material/item/Armor.java
@@ -28,6 +28,7 @@ package org.spout.vanilla.material.item;
 
 public abstract class Armor extends VanillaItemMaterial implements Enchantable {
 	private int protection;
+	private int enchantability;
 
 	protected Armor(String name, int id, int protection) {
 		super(name, id);
@@ -41,5 +42,15 @@ public abstract class Armor extends VanillaItemMaterial implements Enchantable {
 	@Override
 	public boolean getNBTData() {
 		return true;
+	}
+
+	@Override
+	public int getEnchantability() {
+		return enchantability;
+	}
+
+	@Override
+	public void setEnchantability(int enchantability) {
+		this.enchantability = enchantability;
 	}
 }

--- a/src/main/java/org/spout/vanilla/material/item/Enchantable.java
+++ b/src/main/java/org/spout/vanilla/material/item/Enchantable.java
@@ -31,8 +31,14 @@ package org.spout.vanilla.material.item;
  */
 public interface Enchantable {
 	/**
-	 * Gets the enchantibility of this item material to use in the process of enchanting
-	 * @return Enchantibility level of this item material
+	 * Gets the enchantability of this item material to use in the process of enchanting
+	 * @return Enchantability level of this item material
 	 */
-	public int getEnchantibility();
+	public int getEnchantability();
+
+	/**
+	 * Sets the enchantability of this item material
+	 * @param enchantability Enchantability to set
+	 */
+	public void setEnchantability(int enchantability);
 }

--- a/src/main/java/org/spout/vanilla/material/item/armor/chain/ChainArmor.java
+++ b/src/main/java/org/spout/vanilla/material/item/armor/chain/ChainArmor.java
@@ -31,10 +31,6 @@ import org.spout.vanilla.material.item.Armor;
 public abstract class ChainArmor extends Armor {
 	protected ChainArmor(String name, int id, int protection) {
 		super(name, id, protection);
-	}
-
-	@Override
-	public int getEnchantibility() {
-		return 12;
+		this.setEnchantability(12);
 	}
 }

--- a/src/main/java/org/spout/vanilla/material/item/armor/diamond/DiamondArmor.java
+++ b/src/main/java/org/spout/vanilla/material/item/armor/diamond/DiamondArmor.java
@@ -31,10 +31,6 @@ import org.spout.vanilla.material.item.Armor;
 public abstract class DiamondArmor extends Armor {
 	protected DiamondArmor(String name, int id, int protection) {
 		super(name, id, protection);
-	}
-
-	@Override
-	public int getEnchantibility() {
-		return 10;
+		this.setEnchantability(10);
 	}
 }

--- a/src/main/java/org/spout/vanilla/material/item/armor/iron/IronArmor.java
+++ b/src/main/java/org/spout/vanilla/material/item/armor/iron/IronArmor.java
@@ -31,10 +31,6 @@ import org.spout.vanilla.material.item.Armor;
 public abstract class IronArmor extends Armor {
 	protected IronArmor(String name, int id, int protection) {
 		super(name, id, protection);
-	}
-
-	@Override
-	public int getEnchantibility() {
-		return 9;
+		this.setEnchantability(9);
 	}
 }

--- a/src/main/java/org/spout/vanilla/material/item/armor/leather/LeatherArmor.java
+++ b/src/main/java/org/spout/vanilla/material/item/armor/leather/LeatherArmor.java
@@ -31,10 +31,6 @@ import org.spout.vanilla.material.item.Armor;
 public abstract class LeatherArmor extends Armor {
 	protected LeatherArmor(String name, int id, int protection) {
 		super(name, id, protection);
-	}
-
-	@Override
-	public int getEnchantibility() {
-		return 15;
+		this.setEnchantability(15);
 	}
 }

--- a/src/main/java/org/spout/vanilla/material/item/tool/FishingRod.java
+++ b/src/main/java/org/spout/vanilla/material/item/tool/FishingRod.java
@@ -24,13 +24,11 @@
  * License and see <http://www.spout.org/SpoutDevLicenseV1.txt> for the full license,
  * including the MIT license.
  */
-package org.spout.vanilla.material.item.armor.gold;
+package org.spout.vanilla.material.item.tool;
 
-import org.spout.vanilla.material.item.Armor;
 
-public abstract class GoldArmor extends Armor {
-	protected GoldArmor(String name, int id, int protection) {
-		super(name, id, protection);
-		this.setEnchantability(25);
+public class FishingRod extends Tool {
+	public FishingRod(String name, int id, short durability) {
+		super(name, id, durability);
 	}
 }

--- a/src/main/java/org/spout/vanilla/material/item/tool/InteractTool.java
+++ b/src/main/java/org/spout/vanilla/material/item/tool/InteractTool.java
@@ -26,7 +26,7 @@
  */
 package org.spout.vanilla.material.item.tool;
 
-public class InteractTool extends Tool {
+public abstract class InteractTool extends Tool {
 	public InteractTool(String name, int id, short durability) {
 		super(name, id, durability);
 	}

--- a/src/main/java/org/spout/vanilla/material/item/tool/diamond/DiamondTool.java
+++ b/src/main/java/org/spout/vanilla/material/item/tool/diamond/DiamondTool.java
@@ -32,10 +32,6 @@ import org.spout.vanilla.material.item.tool.Tool;
 public abstract class DiamondTool extends Tool implements Enchantable {
 	protected DiamondTool(String name, int id, short durability) {
 		super(name, id, durability);
-	}
-
-	@Override
-	public int getEnchantibility() {
-		return 10;
+		this.setEnchantability(10);
 	}
 }

--- a/src/main/java/org/spout/vanilla/material/item/tool/gold/GoldTool.java
+++ b/src/main/java/org/spout/vanilla/material/item/tool/gold/GoldTool.java
@@ -32,10 +32,6 @@ import org.spout.vanilla.material.item.tool.Tool;
 public abstract class GoldTool extends Tool implements Enchantable {
 	protected GoldTool(String name, int id, short durability) {
 		super(name, id, durability);
-	}
-
-	@Override
-	public int getEnchantibility() {
-		return 22;
+		this.setEnchantability(22);
 	}
 }

--- a/src/main/java/org/spout/vanilla/material/item/tool/iron/IronTool.java
+++ b/src/main/java/org/spout/vanilla/material/item/tool/iron/IronTool.java
@@ -32,10 +32,6 @@ import org.spout.vanilla.material.item.tool.Tool;
 public abstract class IronTool extends Tool implements Enchantable {
 	protected IronTool(String name, int id, short durability) {
 		super(name, id, durability);
-	}
-
-	@Override
-	public int getEnchantibility() {
-		return 14;
+		this.setEnchantability(14);
 	}
 }

--- a/src/main/java/org/spout/vanilla/material/item/tool/stone/StoneTool.java
+++ b/src/main/java/org/spout/vanilla/material/item/tool/stone/StoneTool.java
@@ -26,16 +26,11 @@
  */
 package org.spout.vanilla.material.item.tool.stone;
 
-import org.spout.vanilla.material.item.Enchantable;
 import org.spout.vanilla.material.item.tool.Tool;
 
-public abstract class StoneTool extends Tool implements Enchantable {
+public abstract class StoneTool extends Tool {
 	protected StoneTool(String name, int id, short durability) {
 		super(name, id, durability);
-	}
-
-	@Override
-	public int getEnchantibility() {
-		return 5;
+		this.setEnchantability(5);
 	}
 }

--- a/src/main/java/org/spout/vanilla/material/item/tool/wood/WoodenTool.java
+++ b/src/main/java/org/spout/vanilla/material/item/tool/wood/WoodenTool.java
@@ -26,16 +26,11 @@
  */
 package org.spout.vanilla.material.item.tool.wood;
 
-import org.spout.vanilla.material.item.Enchantable;
 import org.spout.vanilla.material.item.tool.Tool;
 
-public abstract class WoodenTool extends Tool implements Enchantable {
+public abstract class WoodenTool extends Tool {
 	protected WoodenTool(String name, int id, short durability) {
 		super(name, id, durability);
-	}
-
-	@Override
-	public int getEnchantibility() {
-		return 15;
+		this.setEnchantability(15);
 	}
 }

--- a/src/main/java/org/spout/vanilla/material/item/weapon/Bow.java
+++ b/src/main/java/org/spout/vanilla/material/item/weapon/Bow.java
@@ -32,11 +32,6 @@ import org.spout.vanilla.material.item.RangedWeapon;
 public class Bow extends RangedWeapon implements Enchantable {
 	public Bow(String name, int id, short durability) {
 		super(name, id, durability);
-		this.setRangedDamage(9);
-	}
-
-	@Override
-	public int getEnchantibility() {
-		return 1;
+		this.setRangedDamage(9).setEnchantability(1);
 	}
 }

--- a/src/main/java/org/spout/vanilla/protocol/handler/EntityInteractionMessageHandler.java
+++ b/src/main/java/org/spout/vanilla/protocol/handler/EntityInteractionMessageHandler.java
@@ -37,8 +37,11 @@ import org.spout.api.protocol.Session;
 import org.spout.vanilla.configuration.VanillaConfiguration;
 import org.spout.vanilla.controller.VanillaActionController;
 import org.spout.vanilla.controller.living.player.VanillaPlayer;
+import org.spout.vanilla.controller.source.DamageCause;
 import org.spout.vanilla.material.VanillaMaterial;
 import org.spout.vanilla.material.VanillaMaterials;
+import org.spout.vanilla.material.item.tool.Tool;
+import org.spout.vanilla.material.item.weapon.Sword;
 import org.spout.vanilla.protocol.msg.EntityInteractionMessage;
 import org.spout.vanilla.util.VanillaPlayerUtil;
 
@@ -56,6 +59,7 @@ public class EntityInteractionMessageHandler extends MessageHandler<EntityIntera
 			holdingMat = VanillaMaterials.AIR;
 		}
 		if (message.isPunching()) {
+			VanillaPlayer vPlayer = (VanillaPlayer) player.getEntity().getController();
 			holdingMat.onInteract(player.getEntity(), clickedEntity, Action.LEFT_CLICK);
 
 			if (clickedEntity.getController() instanceof VanillaPlayer && !VanillaConfiguration.PLAYER_PVP_ENABLED.getBoolean()) {
@@ -63,14 +67,20 @@ public class EntityInteractionMessageHandler extends MessageHandler<EntityIntera
 			}
 
 			if (clickedEntity.getController() instanceof VanillaActionController) {
+				VanillaActionController damaged = (VanillaActionController) clickedEntity.getController();
 				int damage = 1;
 				if (holding != null && holdingMat != null && holdingMat instanceof VanillaMaterial) {
 					damage = ((VanillaMaterial) holdingMat).getDamage();
+					if (holdingMat instanceof Sword) {
+						// This is a bit of a hack due to the way Tool hierarchy is now (Only Swords can have a damage modifier, but Sword must be an interface and therefore is not able to contain getDamageModifier without code duplication)
+						damage += ((Tool) holdingMat).getDamageModifier(damaged, holding);
+					}
+
+					vPlayer.getInventory().addCurrentItemData(1);
 				}
 				if (damage != 0) {
-					VanillaActionController temp = (VanillaActionController) clickedEntity.getController();
-					if (!temp.getParent().isDead()) {
-						temp.damage(damage, damage > 0);
+					if (!damaged.getParent().isDead()) {
+						damaged.damage(damage, new DamageCause(DamageCause.Type.ATTACK), vPlayer, damage > 0);
 					}
 				}
 			}


### PR DESCRIPTION
Signed-off-by: aPunch theapunch@yahoo.com

This pull changes getDrops to allow for source-based drops, such as cooked meat if a chicken was last damaged by fire. It also adds a DamageCause source for possible damage causes. Some HealthChangeReason's were moved to DamageCause. A new "DAMAGE" HealthChangeReason has been added that points to DamageCause.

In the second commit, I made changes to enchantability and added SMITE, BANE_OF_ARTHROPODS, AND SHARPNESS. Zidane wanted separate commits for different functions.
