### PR TITLE
Hackish pom.xml fix - previous syntax is invalid XML.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
 					<target>1.6</target>
 					<compilerArguments>
 						<Xlint:all/>
-						<Xlint:-path/>
+						<O>-Xlint:-path</O>
 					</compilerArguments>
 					<showWarnings>true</showWarnings>
 					<showDeprecation>true</showDeprecation>


### PR DESCRIPTION
However Maven handles it fine. Unfortunately, IDEA is more picky. This fix works as the "-O" option is a legacy option which javac ignores, instead of throwing an error, and then parses the next part of that argument. May break with future compilers.
