### PR TITLE
Fixed item picking up - no longer telling the player that the item has to pick up the player.

### DIFF
--- a/src/main/java/org/spout/vanilla/controller/object/moving/Item.java
+++ b/src/main/java/org/spout/vanilla/controller/object/moving/Item.java
@@ -113,7 +113,7 @@ public class Item extends Substance {
 
 		int collected = getParent().getId();
 		int collector = entity.getId();
-		sendPacketsToNearbyPlayers(entity.getPosition(), entity.getViewDistance(), new CollectItemMessage(collector, collected));
+		sendPacketsToNearbyPlayers(entity.getPosition(), entity.getViewDistance(), new CollectItemMessage(collected, collector));
 		((VanillaPlayer) entity.getController()).getInventory().getBase().addItem(is, true, true);
 		getParent().kill();
 	}


### PR DESCRIPTION
ClassCastExceptions everywhere. Mojang, y u no use instanceof in your clients?

Signed-off-by: nallar rallanpcl@gmail.com
