### PR TITLE
Rewrite of recipes

### DIFF
--- a/src/main/java/org/spout/vanilla/inventory/recipe/SimpleShapedRecipe.java
+++ b/src/main/java/org/spout/vanilla/inventory/recipe/SimpleShapedRecipe.java
@@ -26,24 +26,23 @@
  */
 package org.spout.vanilla.inventory.recipe;
 
-import org.spout.api.inventory.ShapelessRecipe;
+import org.spout.api.inventory.ShapedRecipe;
 import org.spout.api.material.Material;
 
 
-/**
- * Takes in a variable material input amount and gives a variable material output amount (Shapeless).
- */
-public class SingleShapelessInputOutputRecipe extends ShapelessRecipe {
-	Material material;
+public class SimpleShapedRecipe extends ShapedRecipe{
+	private Material material;
 
-	public SingleShapelessInputOutputRecipe(VanillaRecipeBuilder<?> builder) {
-	    super(builder);
-	    material = getIngredients().get(0);
+	public SimpleShapedRecipe(VanillaRecipeBuilder<?> builder) {
+		super(builder);
+		if (builder.majorMaterial == null) {
+			material = builder.ingredients.get(0);
+		} else {
+			material = builder.majorMaterial;
+		}
 	}
 	
 	public Material getMaterial() {
-	    return material;
+		return material;
 	}
-	
-	
 }

--- a/src/main/java/org/spout/vanilla/inventory/recipe/SimpleShapedToolRecipe.java
+++ b/src/main/java/org/spout/vanilla/inventory/recipe/SimpleShapedToolRecipe.java
@@ -26,59 +26,53 @@
  */
 package org.spout.vanilla.inventory.recipe;
 
-import java.util.ArrayList;
 
-import org.spout.api.Spout;
-import org.spout.api.entity.Controller;
-import org.spout.api.inventory.ItemStack;
 import org.spout.api.inventory.ShapedRecipe;
 import org.spout.api.material.Material;
 
-import org.spout.vanilla.VanillaPlugin;
 
-public class SimpleShapedToolRecipe {
-	/**
-	 * Constructs a tool recipe given a few constrains. It can have only two materials within the recipe (namely one major and one minor material). This recipe should only be used
-	 * for recipes such as a Wooden Sword or a Wooden Pickaxe; both which have a 3x3 crafting recipe that have a major (plank) and minor (stick) material with everything else in
-	 * the matrix as null.
-	 * <p/>
-	 * Example:
-	 * ---------------------
-	 * | Plank Plank Plank |
-	 * | Null  Stick Null  |
-	 * | Null  Stick Null  |
-	 * ---------------------
-	 * @param instance Instance of our plugin
-	 * @param craftingEnabler The controller that would "manage" this recipe. Example would be CraftingController or VanillaPlayer (as part of their inventory would be a crafting matrix).
-	 * @param name Name of the recipe
-	 * @param major The main ingredient of the recipe
-	 * @param minor The minor ingredient of the recipe
-	 * @param majorC Character represents major ingredient
-	 * @param minorC Character represents minor ingredient
-	 * @param emptyC Character represents empty crafting matrix slot
-	 * @param result The resulting item stack
-	 * @param rows The rows that should be registered for the recipe. This can be any amount (variable).
-	 */
-	public SimpleShapedToolRecipe(VanillaPlugin instance, Controller craftingEnabler, String name, Material major, Material minor, char majorC, char minorC, char emptyC,
-								  ItemStack result, String... rows) {
-		ShapedRecipe recipe = new ShapedRecipe(instance, name, result);
-		//Loop through the strings provided as rows.
-		for (String str : rows) {
-			char[] chars = str.toCharArray();
-			ArrayList<Character> row = new ArrayList<Character>();
-			for (char c : chars) {
-				row.add(c);
-			}
-			if (!row.isEmpty()) {
-				recipe.addRow(row);
-			}
-		}
-		//Assign recipe positions to materials.
-		recipe.getIngredients().put(majorC, major);
-		recipe.getIngredients().put(minorC, minor);
-		recipe.getIngredients().put(emptyC, null);
+/**
+ * Represents a tool recipe with a few constraints. 
+ * It can have only two materials within the recipe (namely one major and one minor material). 
+ * This recipe should only be used for recipes such as a Wooden Sword or a Wooden Pickaxe; both which have a 3x3 crafting recipe 
+ * that have a major (plank) and minor (stick) material with everything else in the matrix as null.
+ * <p/>
+ * Example:
+ * ---------------------
+ * | Plank Plank Plank |
+ * | Null  Stick Null  |
+ * | Null  Stick Null  |
+ * ---------------------
+ * 
+ */
+public class SimpleShapedToolRecipe extends ShapedRecipe{
+	private Material majorMaterial;
+	private Material minorMaterial;
+	private Character majorChar;
+	private Character minorChar;
 
-		//Register the recipe
-		Spout.getEngine().getRecipeManager().addRecipe(recipe);
+	public SimpleShapedToolRecipe(VanillaRecipeBuilder<?> builder) {
+	    super(builder);
+	    this.majorMaterial = builder.majorMaterial;
+	    this.minorMaterial = builder.minorMaterial;
+	    this.majorChar = builder.majorChar;
+	    this.minorChar = builder.minorChar;
+	    
+	}
+
+	public Material getMajorMaterial() {
+	    return majorMaterial;
+	}
+	
+	public Material getMinorMaterial() {
+	    return minorMaterial;
+	}
+
+	public Character getMajorChar() {
+	    return majorChar;
+	}
+
+	public Character getMinorChar() {
+	    return minorChar;
 	}
 }

--- a/src/main/java/org/spout/vanilla/inventory/recipe/VanillaRecipeBuilder.java
+++ b/src/main/java/org/spout/vanilla/inventory/recipe/VanillaRecipeBuilder.java
@@ -1,0 +1,121 @@
+/*
+ * This file is part of Vanilla.
+ *
+ * Copyright (c) 2011-2012, SpoutDev <http://www.spout.org/>
+ * Vanilla is licensed under the SpoutDev License Version 1.
+ *
+ * Vanilla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In addition, 180 days after any changes are published, you can use the
+ * software, incorporating those changes, under the terms of the MIT license,
+ * as described in the SpoutDev License Version 1.
+ *
+ * Vanilla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License,
+ * the MIT license and the SpoutDev License Version 1 along with this program.
+ * If not, see <http://www.gnu.org/licenses/> for the GNU Lesser General Public
+ * License and see <http://www.spout.org/SpoutDevLicenseV1.txt> for the full license,
+ * including the MIT license.
+ */
+package org.spout.vanilla.inventory.recipe;
+
+import org.spout.api.inventory.RecipeBuilder;
+import org.spout.api.material.Material;
+
+@SuppressWarnings("unchecked")
+public class VanillaRecipeBuilder<T extends VanillaRecipeBuilder<?>> extends RecipeBuilder<VanillaRecipeBuilder<?>>{
+	public Material majorMaterial;
+	public Material minorMaterial;
+	public Character majorChar;
+	public Character minorChar;
+	
+	public static VanillaRecipeBuilder<?> create() {
+		return new VanillaRecipeBuilder<VanillaRecipeBuilder<?>>();
+	}
+	
+	public SimpleShapedRecipe buildSimpleShapedRecipe() {
+		if (ingredientsMap.size() > 1) {
+			throw new IllegalStateException("Tried to create a SimpleShapedRecipe, but the recipe contains too many materials.");
+		} else if (ingredientsMap.size() < 1) {
+			if (majorMaterial != null && majorChar != null) {
+				ingredientsMap.clear();
+				ingredientsMap.put(majorChar, majorMaterial);
+			} else {
+				throw new IllegalStateException("Tried to create a SimpleShapedRecipe, but there was not enough information.");
+			}
+		}
+		return new SimpleShapedRecipe(this);
+	}
+
+	public SimpleShapedToolRecipe buildSimpleShapedToolRecipe() {
+		if (majorMaterial == null || minorMaterial == null || minorChar == null || majorChar == null) {
+			if (ingredientsMap.size() < 2) {
+				throw new IllegalStateException("Tried to create a SimpleShapedToolRecipe, but there was not enough information.");
+			} else if (ingredientsMap.size() > 2) {
+				throw new IllegalStateException("Tried to create a SimpleShapedToolRecipe, but the recipe contains too many materials.");
+			} else {
+				minorChar = (Character) ingredientsMap.keySet().toArray()[0];
+				majorChar = (Character) ingredientsMap.keySet().toArray()[1];
+				minorMaterial = (Material) ingredientsMap.values().toArray()[0];
+				majorMaterial = (Material) ingredientsMap.values().toArray()[1];
+			}
+		}
+		ingredientsMap.clear();
+		ingredientsMap.put(majorChar, majorMaterial);
+		ingredientsMap.put(minorChar, minorMaterial);
+		return new SimpleShapedToolRecipe(this);
+	}
+
+	public SingleShapelessInputOutputRecipe buildSingleShapelessInputOutputRecipe() {
+		if (ingredients.isEmpty() ) {
+			if (ingredientsMap.values().size() > 0) {
+				ingredients.addAll(ingredientsMap.values());
+			} else {
+				throw new IllegalStateException("Tried to create a SingleShapelessInputOutputRecipe, but there were not enough materials.");
+			}
+		}
+		if (ingredients.size() > 1) {
+			throw new IllegalStateException("Tried to create a SingleShapelessInputOutputRecipe, but the recipe contains too many materials.");
+		}
+		return new SingleShapelessInputOutputRecipe(this);
+	}
+
+
+	/**
+	 * Set the value of minorMaterial
+	 *
+	 * @param c Character that represents the material
+	 * @param material Material to set
+	 * @return this 
+	 */
+	public T setMinorMaterial(Character c, Material material) {
+		this.minorMaterial = material;
+		this.minorChar = c;
+		addIngredient(material);
+		return (T) this;
+	}
+
+
+	/**
+	 * Set the value of majorMaterial. Can be used as a shortcut method for Recipes that use both a major and minor material.
+	 * Also functions as the material in recipes with a single material.
+	 *
+	 * @param c Character that represents the material
+	 * @param material Material to set
+	 * @return this 
+	 */
+
+	public T setMajorMaterial(Character c, Material material) {
+		this.majorMaterial = material;
+		this.majorChar = c;
+		addIngredient(material);
+		return (T) this;
+	}
+}

--- a/src/main/java/org/spout/vanilla/inventory/recipe/VanillaRecipes.java
+++ b/src/main/java/org/spout/vanilla/inventory/recipe/VanillaRecipes.java
@@ -26,23 +26,26 @@
  */
 package org.spout.vanilla.inventory.recipe;
 
-import org.spout.api.inventory.ItemStack;
+import org.spout.api.Spout;
+import org.spout.api.inventory.Recipe;
 
-import org.spout.vanilla.VanillaPlugin;
 import org.spout.vanilla.material.VanillaMaterials;
 import org.spout.vanilla.material.item.misc.Dye;
+import static org.spout.vanilla.inventory.recipe.VanillaRecipeBuilder.create;
 
 public class VanillaRecipes {
-	public final SingleShapelessInputOutputRecipe WOODEN_PLANK;
-	public final SingleShapelessInputOutputRecipe BONE_MEAL;
-	public final SimpleShapedToolRecipe WOODEN_PICKAXE;
+	public static final SingleShapelessInputOutputRecipe WOODEN_PLANK;
+	public static final SingleShapelessInputOutputRecipe BONE_MEAL;
+	public static final SimpleShapedToolRecipe WOODEN_PICKAXE;
+	
+	static {
+		WOODEN_PLANK = add(create().setResult(VanillaMaterials.PLANK, 4).addIngredient(VanillaMaterials.LOG).buildSingleShapelessInputOutputRecipe());
+		BONE_MEAL = add(create().setResult(Dye.BONE_MEAL, 3).addIngredient(VanillaMaterials.BONE).buildSingleShapelessInputOutputRecipe());
+		WOODEN_PICKAXE = add(create().setResult(VanillaMaterials.WOODEN_PICKAXE, 1).setMajorMaterial('P', VanillaMaterials.PLANK).setMinorMaterial('S', VanillaMaterials.STICK).addRow("PPP").addRow("ESE").addRow("ESE").buildSimpleShapedToolRecipe());
+	}
 
-	public VanillaRecipes(final VanillaPlugin instance) {
-		/**
-		 * Examples...I need feedback!
-		 */
-		WOODEN_PLANK = new SingleShapelessInputOutputRecipe(instance, null, "Wooden Plank", VanillaMaterials.LOG, 1, 'L', VanillaMaterials.PLANK, 4);
-		BONE_MEAL = new SingleShapelessInputOutputRecipe(instance, null, "Bone Meal", VanillaMaterials.BONE, 1, 'B', Dye.BONE_MEAL, 3);
-		WOODEN_PICKAXE = new SimpleShapedToolRecipe(instance, null, "Wooden Pickaxe", VanillaMaterials.PLANK, VanillaMaterials.STICK, 'P', 'S', 'E', new ItemStack(VanillaMaterials.WOODEN_PICKAXE, 1), "PPP", "ESE", "ESE");
+	private static <T extends Recipe> T add(T recipe) {
+		Spout.getEngine().getRecipeManager().addRecipe(recipe);
+		return recipe;
 	}
 }

--- a/src/test/java/org/spout/vanilla/inventory/recipe/RecipeBuilderTest.java
+++ b/src/test/java/org/spout/vanilla/inventory/recipe/RecipeBuilderTest.java
@@ -1,0 +1,170 @@
+/*
+ * This file is part of Vanilla.
+ *
+ * Copyright (c) 2011-2012, SpoutDev <http://www.spout.org/>
+ * Vanilla is licensed under the SpoutDev License Version 1.
+ *
+ * Vanilla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In addition, 180 days after any changes are published, you can use the
+ * software, incorporating those changes, under the terms of the MIT license,
+ * as described in the SpoutDev License Version 1.
+ *
+ * Vanilla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License,
+ * the MIT license and the SpoutDev License Version 1 along with this program.
+ * If not, see <http://www.gnu.org/licenses/> for the GNU Lesser General Public
+ * License and see <http://www.spout.org/SpoutDevLicenseV1.txt> for the full license,
+ * including the MIT license.
+ */
+package org.spout.vanilla.inventory.recipe;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import org.junit.Test;
+
+import org.spout.api.inventory.RecipeBuilder;
+import org.spout.api.inventory.ShapedRecipe;
+import org.spout.api.inventory.ShapelessRecipe;
+import org.spout.api.material.Material;
+
+import org.spout.vanilla.material.VanillaMaterials;
+
+public class RecipeBuilderTest {
+    
+    @Test
+    public void singleIngredientsTest() {
+	    RecipeBuilder<RecipeBuilder<?>> builder = new RecipeBuilder<RecipeBuilder<?>>();
+	    builder.addIngredient(VanillaMaterials.DIAMOND).addIngredient(VanillaMaterials.DIAMOND_BLOCK);
+	    builder.addIngredient(VanillaMaterials.DIRT, 2);
+	    ShapelessRecipe recipe = builder.buildShapelessRecipe();
+	    List<Material> materials = new ArrayList<Material>();
+	    materials.add(VanillaMaterials.DIAMOND);
+	    materials.add(VanillaMaterials.DIAMOND_BLOCK);
+	    materials.add(VanillaMaterials.DIRT);
+	    materials.add(VanillaMaterials.DIRT);
+	    for (Material m : recipe.getIngredients()) {
+		    assertTrue(materials.remove(m));
+	    }
+	    assertTrue(materials.isEmpty());  
+    }
+    
+    @Test
+    public void characterIngredientsTest() {
+	    RecipeBuilder<RecipeBuilder<?>> builder = new RecipeBuilder<RecipeBuilder<?>>();
+	    builder.addIngredient(VanillaMaterials.ARROW).addIngredient(VanillaMaterials.BEDROCK);
+	    builder.addIngredient(VanillaMaterials.CACTUS);
+	    ShapelessRecipe recipe = builder.buildShapelessRecipe();
+	    List<Material> testIngredients = new ArrayList<Material>();
+	    List<Material> recipeIngredients = new ArrayList<Material>();
+	    System.out.println("Recipe: " + testIngredients);
+	    recipeIngredients.addAll(recipe.getIngredients());
+	    testIngredients.add(VanillaMaterials.ARROW);
+	    testIngredients.add(VanillaMaterials.BEDROCK);
+	    testIngredients.add(VanillaMaterials.CACTUS);
+	    System.out.println("Test: " + testIngredients);
+	    recipeIngredients.removeAll(testIngredients);
+	    testIngredients.removeAll(recipe.getIngredients());
+	    assertTrue(testIngredients.isEmpty());
+	    assertTrue(recipeIngredients.isEmpty());
+    }
+    
+    @Test
+    public void overwritingMaterialsTest() {
+	    RecipeBuilder<RecipeBuilder<?>> builder = new RecipeBuilder<RecipeBuilder<?>>();
+	    builder.addIngredient('A', VanillaMaterials.ARROW).addIngredient('B', VanillaMaterials.BEDROCK);
+	    builder.addIngredient('B', VanillaMaterials.CACTUS).addIngredient('A', VanillaMaterials.DIRT);
+	    ShapedRecipe recipe = builder.buildShapedRecipe();
+	    List<Material> testIngredients = new ArrayList<Material>();
+	    List<Material> recipeIngredients = new ArrayList<Material>();
+	    recipeIngredients.addAll(recipe.getIngredients());
+	    testIngredients.add(VanillaMaterials.CACTUS);
+	    testIngredients.add(VanillaMaterials.DIRT);
+	    recipeIngredients.removeAll(testIngredients);
+	    testIngredients.removeAll(recipe.getIngredients());
+	    assertTrue(testIngredients.isEmpty());
+	    assertTrue(recipeIngredients.isEmpty());
+    }
+    
+    @Test
+    public void shapedAmountsTest() {
+	    RecipeBuilder<RecipeBuilder<?>> builder = new RecipeBuilder<RecipeBuilder<?>>();
+	    builder.addIngredient('A', VanillaMaterials.ARROW).addIngredient('B', VanillaMaterials.BEDROCK);
+	    builder.addRow("AAA").addRow("BBB").addRow("AAA");
+	    ShapedRecipe recipe = builder.buildShapedRecipe();
+	    List<Material> testIngredients = new ArrayList<Material>();
+	    List<Material> recipeIngredients = new ArrayList<Material>();
+	    recipeIngredients.addAll(recipe.getIngredients());
+	    testIngredients.add(VanillaMaterials.ARROW);
+	    testIngredients.add(VanillaMaterials.BEDROCK);
+	    recipeIngredients.removeAll(testIngredients);
+	    testIngredients.removeAll(recipe.getIngredients());
+	    assertTrue(testIngredients.isEmpty());
+	    assertTrue(recipeIngredients.isEmpty());
+    }
+    
+    @Test
+    public void rowsTest() {
+	    RecipeBuilder<RecipeBuilder<?>> builder = new RecipeBuilder<RecipeBuilder<?>>();
+	    builder.addIngredient('A', VanillaMaterials.ARROW).addIngredient('B', VanillaMaterials.BEDROCK);
+	    builder.addRow("AAA").addRow("BBB").addRow("AAA");
+	    ShapedRecipe recipe = builder.buildShapedRecipe();
+	    List<List<Character>> rows = recipe.getRows();
+	    assertTrue(rows.get(0).get(0) == 'A');
+	    assertTrue(rows.get(0).get(1) == 'A');
+	    assertTrue(rows.get(0).get(2) == 'A');
+	    assertTrue(rows.get(1).get(0) == 'B');
+	    assertTrue(rows.get(1).get(1) == 'B');
+	    assertTrue(rows.get(1).get(2) == 'B');
+	    assertTrue(rows.get(2).get(0) == 'A');
+	    assertTrue(rows.get(2).get(1) == 'A');
+	    assertTrue(rows.get(2).get(2) == 'A');
+    }
+    
+    @Test
+    public void replaceRowsTest() {
+	    RecipeBuilder<RecipeBuilder<?>> builder = new RecipeBuilder<RecipeBuilder<?>>();
+	    builder.addIngredient('A', VanillaMaterials.ARROW).addIngredient('B', VanillaMaterials.BEDROCK);
+	    builder.addRow("AAA").addRow("BBB").addRow("AAA").replaceRow(1, "CCC");
+	    ShapedRecipe recipe = builder.buildShapedRecipe();
+	    List<List<Character>> rows = recipe.getRows();
+	    assertTrue(rows.get(0).get(0) == 'A');
+	    assertTrue(rows.get(0).get(1) == 'A');
+	    assertTrue(rows.get(0).get(2) == 'A');
+	    assertTrue(rows.get(1).get(0) == 'C');
+	    assertTrue(rows.get(1).get(1) == 'C');
+	    assertTrue(rows.get(1).get(2) == 'C');
+	    assertTrue(rows.get(2).get(0) == 'A');
+	    assertTrue(rows.get(2).get(1) == 'A');
+	    assertTrue(rows.get(2).get(2) == 'A');
+    }
+    
+    @Test
+    public void cloneTest() {
+	    RecipeBuilder<RecipeBuilder<?>> builder = new RecipeBuilder<RecipeBuilder<?>>();
+	    builder.addIngredient('A', VanillaMaterials.ARROW).addIngredient('B', VanillaMaterials.BEDROCK);
+	    builder.addRow("AAA").addRow("BBB").addRow("AAA");
+	    ShapedRecipe recipe1 = builder.buildShapedRecipe();
+	    RecipeBuilder<RecipeBuilder<?>> builder2 = new RecipeBuilder<RecipeBuilder<?>>();
+	    builder2.clone(recipe1);
+	    builder2.replaceRow(1, "CCC");
+	    ShapedRecipe recipe2 = builder2.buildShapedRecipe();
+	    assertTrue(!recipe1.equals(recipe2));
+	    RecipeBuilder<RecipeBuilder<?>> builder3 = new RecipeBuilder<RecipeBuilder<?>>();
+	    builder3.addIngredient('A', VanillaMaterials.ARROW).addIngredient('B', VanillaMaterials.BEDROCK);
+	    builder3.addRow("AAA").addRow("CCC").addRow("AAA");
+	    ShapedRecipe recipe3 = builder3.buildShapedRecipe();
+	    assertTrue(recipe2.equals(recipe3));
+    }
+}


### PR DESCRIPTION
This is a rewrite of recipes. This uses a builder pattern, and makes recipes immutable. Example implementations are in VanillaRecipes, but because @Olloth wants to make them parsed from a file, I didn't put all of them. I welcome all commentary.

Corresponding SpoutAPI Pull: https://github.com/SpoutDev/SpoutAPI/pull/235
One issue: http://issues.spout.org/browse/SPOUTAPI-15
