### PR TITLE
VANILLA-122

### DIFF
--- a/src/main/java/org/spout/vanilla/material/VanillaMaterials.java
+++ b/src/main/java/org/spout/vanilla/material/VanillaMaterials.java
@@ -527,9 +527,11 @@ public final class VanillaMaterials {
 					if (temp instanceof VanillaMaterial) {
 						VanillaMaterial material = (VanillaMaterial) temp;
 						if (material != null) {
-							if (!((Material) material).isSubMaterial()) {
-								reverseTable.put((short) material.getMinecraftId(), (Material) material);
+							Material mat = (Material) material;
+							if (mat.isSubMaterial()) {
+								mat = mat.getParentMaterial();
 							}
+							reverseTable.put((short) material.getMinecraftId(), mat);
 						}
 					}
 				}


### PR DESCRIPTION
Signed-off-by: aPunch theapunch@yahoo.com

Before, materials such as tall grass and spawn eggs were not being registered because they specified a material with data not equal to zero (TallGrass.TALL_GRASS is of data value 1, SpawnEgg.PIG is of data value 90). This pull first checks if the material is a sub material, and registers its parent if so. Otherwise, the material is registered as normal.
