### PR TITLE
Universal Plug and Play by using cling libraries

### DIFF
--- a/src/main/java/org/spout/vanilla/VanillaPlugin.java
+++ b/src/main/java/org/spout/vanilla/VanillaPlugin.java
@@ -85,6 +85,7 @@ public class VanillaPlugin extends CommonPlugin {
 	private Engine engine;
 	private VanillaConfiguration config;
 	private static VanillaPlugin instance;
+	private int port = 25565;
 
 	@Override
 	public void onDisable() {
@@ -105,6 +106,14 @@ public class VanillaPlugin extends CommonPlugin {
 		} catch (ConfigurationException e) {
 			getLogger().log(Level.WARNING, "Error loading Vanilla configuration: ", e);
 		}
+
+		//Universal Plug and Play
+		if (engine.getPlatform() == Platform.SERVER || engine.getPlatform() == Platform.PROXY) {
+			if (VanillaConfiguration.UPNP.getBoolean()) {
+				((Server)engine).mapUPnPPort(port, VanillaConfiguration.MOTD.getString());
+			}
+		}
+
 		//Commands
 		CommandRegistrationsFactory<Class<?>> commandRegFactory = new AnnotatedCommandRegistrationFactory(new SimpleInjector(this), new SimpleAnnotatedCommandExecutorFactory());
 		engine.getRootCommand().addSubCommands(this, AdministrationCommands.class, commandRegFactory);
@@ -137,7 +146,6 @@ public class VanillaPlugin extends CommonPlugin {
 		Spout.getFilesystem().registerLoader("recipe", new RecipeLoader());
 
 		if (engine.getPlatform() == Platform.SERVER || engine.getPlatform() == Platform.PROXY) {
-			int port = 25565;
 			String[] split = engine.getAddress().split(":");
 			if (split.length > 1) {
 				try {
@@ -245,7 +253,7 @@ public class VanillaPlugin extends CommonPlugin {
 
 	/**
 	 * Gets the running instance of VanillaPlugin
-	 * @return
+	 * @return the running instance of VanillaPlugin
 	 */
 	public static VanillaPlugin getInstance() {
 		return instance;

--- a/src/main/java/org/spout/vanilla/configuration/VanillaConfiguration.java
+++ b/src/main/java/org/spout/vanilla/configuration/VanillaConfiguration.java
@@ -38,6 +38,7 @@ import org.spout.vanilla.VanillaPlugin;
 public class VanillaConfiguration extends ConfigurationHolderConfiguration {
 	// General
 	public static final ConfigurationHolder MOTD = new ConfigurationHolder("A Spout Server", "general", "motd");
+	public static final ConfigurationHolder UPNP = new ConfigurationHolder(true, "general", "upnp");
 	public static final ConfigurationHolder ONLINE_MODE = new ConfigurationHolder(true, "general", "online-mode");
 	public static final ConfigurationHolder ENCRYPT_MODE = new ConfigurationHolder(false, "general", "encrypt-mode");
 	public static final ConfigurationHolder ENABLE_END_CREDITS = new ConfigurationHolder(true, "general", "enable-ending-credits");


### PR DESCRIPTION
InetAddress.getLocalHost() is used because mapping the port to 0.0.0.0 did not seem to work. Which would mean that UPNP would not work out of the box since 0.0.0.0:25565 is the default spout address.

Friends were able to join when the upnp setting was true.

I'm not sure if putting everything in Vanilla is the best idea, maybe cling should be shaded to SpoutAPI, or maybe to Spout with some method added to the API.

And last but not least, a related Spout issue: http://issues.spout.org/browse/SPOUT-71

Related:
https://github.com/SpoutDev/Spout/pull/1937
https://github.com/SpoutDev/SpoutAPI/pull/289
