### PR TITLE
Fixed Creature health

### DIFF
--- a/src/main/java/org/spout/vanilla/controller/living/creature/hostile/Blaze.java
+++ b/src/main/java/org/spout/vanilla/controller/living/creature/hostile/Blaze.java
@@ -47,9 +47,9 @@ public class Blaze extends Creature implements Hostile {
 
 	@Override
 	public void onAttached() {
-		setHealth(20, HealthChangeReason.SPAWN);
-		setMaxHealth(20);
 		super.onAttached();
+		setMaxHealth(20);
+		setHealth(20, HealthChangeReason.SPAWN);
 	}
 
 	@Override

--- a/src/main/java/org/spout/vanilla/controller/living/creature/hostile/CaveSpider.java
+++ b/src/main/java/org/spout/vanilla/controller/living/creature/hostile/CaveSpider.java
@@ -36,8 +36,8 @@ public class CaveSpider extends Spider {
 
 	@Override
 	public void onAttached() {
-		setHealth(20, HealthChangeReason.SPAWN);
-		setMaxHealth(20);
 		super.onAttached();
+		setMaxHealth(12);
+		setHealth(12, HealthChangeReason.SPAWN);
 	}
 }

--- a/src/main/java/org/spout/vanilla/controller/living/creature/hostile/Creeper.java
+++ b/src/main/java/org/spout/vanilla/controller/living/creature/hostile/Creeper.java
@@ -47,9 +47,9 @@ public class Creeper extends Creature implements Hostile {
 
 	@Override
 	public void onAttached() {
-		setHealth(20, HealthChangeReason.SPAWN);
-		setMaxHealth(20);
 		super.onAttached();
+		setMaxHealth(20);
+		setHealth(20, HealthChangeReason.SPAWN);
 	}
 
 	@Override

--- a/src/main/java/org/spout/vanilla/controller/living/creature/hostile/Enderdragon.java
+++ b/src/main/java/org/spout/vanilla/controller/living/creature/hostile/Enderdragon.java
@@ -46,9 +46,9 @@ public class Enderdragon extends Creature implements Hostile, Boss {
 
 	@Override
 	public void onAttached() {
-		setHealth(200, HealthChangeReason.SPAWN);
-		setMaxHealth(200);
 		super.onAttached();
+		setMaxHealth(200);
+		setHealth(200, HealthChangeReason.SPAWN);
 	}
 
 	@Override

--- a/src/main/java/org/spout/vanilla/controller/living/creature/hostile/Ghast.java
+++ b/src/main/java/org/spout/vanilla/controller/living/creature/hostile/Ghast.java
@@ -46,9 +46,9 @@ public class Ghast extends Creature implements Hostile {
 
 	@Override
 	public void onAttached() {
-		setHealth(10, HealthChangeReason.SPAWN);
-		setMaxHealth(10);
 		super.onAttached();
+		setMaxHealth(10);
+		setHealth(10, HealthChangeReason.SPAWN);
 	}
 
 	@Override

--- a/src/main/java/org/spout/vanilla/controller/living/creature/hostile/Giant.java
+++ b/src/main/java/org/spout/vanilla/controller/living/creature/hostile/Giant.java
@@ -45,9 +45,9 @@ public class Giant extends Creature implements Hostile {
 
 	@Override
 	public void onAttached() {
-		setHealth(100, HealthChangeReason.SPAWN);
-		setMaxHealth(100);
 		super.onAttached();
+		setMaxHealth(100);
+		setHealth(100, HealthChangeReason.SPAWN);
 	}
 
 	@Override

--- a/src/main/java/org/spout/vanilla/controller/living/creature/hostile/Silverfish.java
+++ b/src/main/java/org/spout/vanilla/controller/living/creature/hostile/Silverfish.java
@@ -45,9 +45,9 @@ public class Silverfish extends Creature implements Hostile {
 
 	@Override
 	public void onAttached() {
-		setHealth(8, HealthChangeReason.SPAWN);
-		setMaxHealth(8);
 		super.onAttached();
+		setMaxHealth(8);
+		setHealth(8, HealthChangeReason.SPAWN);
 	}
 
 	@Override

--- a/src/main/java/org/spout/vanilla/controller/living/creature/hostile/Skeleton.java
+++ b/src/main/java/org/spout/vanilla/controller/living/creature/hostile/Skeleton.java
@@ -49,9 +49,9 @@ public class Skeleton extends Creature implements Hostile {
 
 	@Override
 	public void onAttached() {
-		setHealth(20, HealthChangeReason.SPAWN);
-		setMaxHealth(20);
 		super.onAttached();
+		setMaxHealth(20);
+		setHealth(20, HealthChangeReason.SPAWN);
 	}
 
 	@Override

--- a/src/main/java/org/spout/vanilla/controller/living/creature/hostile/Slime.java
+++ b/src/main/java/org/spout/vanilla/controller/living/creature/hostile/Slime.java
@@ -67,10 +67,10 @@ public class Slime extends Creature implements Hostile {
 
 	@Override
 	public void onAttached() {
-		int health = size > 0 ? size * 4 : 1;
-		setHealth(health, HealthChangeReason.SPAWN);
-		setMaxHealth(health);
 		super.onAttached();
+		int health = size > 0 ? size * 4 : 1;
+		setMaxHealth(health);
+		setHealth(health, HealthChangeReason.SPAWN);
 	}
 
 	@Override

--- a/src/main/java/org/spout/vanilla/controller/living/creature/hostile/Spider.java
+++ b/src/main/java/org/spout/vanilla/controller/living/creature/hostile/Spider.java
@@ -52,9 +52,9 @@ public class Spider extends Creature implements Hostile {
 
 	@Override
 	public void onAttached() {
-		setHealth(16, HealthChangeReason.SPAWN);
-		setMaxHealth(16);
 		super.onAttached();
+		setMaxHealth(16);
+		setHealth(16, HealthChangeReason.SPAWN);
 	}
 
 	@Override

--- a/src/main/java/org/spout/vanilla/controller/living/creature/hostile/Zombie.java
+++ b/src/main/java/org/spout/vanilla/controller/living/creature/hostile/Zombie.java
@@ -52,9 +52,9 @@ public class Zombie extends Creature implements Hostile {
 
 	@Override
 	public void onAttached() {
-		setHealth(16, HealthChangeReason.SPAWN);
-		setMaxHealth(20);
 		super.onAttached();
+		setMaxHealth(20);
+		setHealth(20, HealthChangeReason.SPAWN);
 	}
 
 	@Override

--- a/src/main/java/org/spout/vanilla/controller/living/creature/neutral/Enderman.java
+++ b/src/main/java/org/spout/vanilla/controller/living/creature/neutral/Enderman.java
@@ -52,12 +52,12 @@ public class Enderman extends Creature implements Neutral {
 
 	@Override
 	public void onAttached() {
-		setHealth(40, HealthChangeReason.SPAWN);
+		super.onAttached();
 		setMaxHealth(40);
+		setHealth(40, HealthChangeReason.SPAWN);
 		if (data().containsKey(Data.HELD_ITEM)) {
 			heldItem = data().get(Data.HELD_ITEM);
 		}
-		super.onAttached();
 		getParent().setCollision(new CollisionModel(new BoundingBox(1, 3, 1, 2, 3, 1)));
 	}
 

--- a/src/main/java/org/spout/vanilla/controller/living/creature/neutral/PigZombie.java
+++ b/src/main/java/org/spout/vanilla/controller/living/creature/neutral/PigZombie.java
@@ -47,9 +47,9 @@ public class PigZombie extends Zombie implements Neutral {
 
 	@Override
 	public void onAttached() {
-		setHealth(20, HealthChangeReason.SPAWN);
-		setMaxHealth(20);
 		super.onAttached();
+		setMaxHealth(20);
+		setHealth(20, HealthChangeReason.SPAWN);
 	}
 
 	@Override

--- a/src/main/java/org/spout/vanilla/controller/living/creature/neutral/Wolf.java
+++ b/src/main/java/org/spout/vanilla/controller/living/creature/neutral/Wolf.java
@@ -43,16 +43,15 @@ public class Wolf extends Creature implements Tameable, Neutral {
 
 	@Override
 	public void onAttached() {
+		super.onAttached();
 		// master = data().get("controlling_entity", master);
 		if (master != null) {
-			setHealth(20, HealthChangeReason.SPAWN);
 			setMaxHealth(20);
+			setHealth(20, HealthChangeReason.SPAWN);
 		} else {
-			setHealth(8, HealthChangeReason.SPAWN);
 			setMaxHealth(8);
+			setHealth(8, HealthChangeReason.SPAWN);
 		}
-
-		super.onAttached();
 	}
 
 	@Override

--- a/src/main/java/org/spout/vanilla/controller/living/creature/passive/Chicken.java
+++ b/src/main/java/org/spout/vanilla/controller/living/creature/passive/Chicken.java
@@ -54,11 +54,11 @@ public class Chicken extends Creature implements Passive {
 
 	@Override
 	public void onAttached() {
-		setHealth(4, HealthChangeReason.SPAWN);
+		super.onAttached();
 		setMaxHealth(4);
+		setHealth(4, HealthChangeReason.SPAWN);
 		dropItemLogic = new DropItemTimeBasedLogic(this, VanillaMaterials.EGG, 1, MINIMUM_EGG_BREEDING_TIME, MAXIMUM_EGG_BREEDING_TIME);
 		registerProcess(dropItemLogic);
-		super.onAttached();
 	}
 
 	@Override

--- a/src/main/java/org/spout/vanilla/controller/living/creature/passive/Cow.java
+++ b/src/main/java/org/spout/vanilla/controller/living/creature/passive/Cow.java
@@ -52,9 +52,9 @@ public class Cow extends Creature implements Passive {
 
 	@Override
 	public void onAttached() {
-		setHealth(4, HealthChangeReason.SPAWN);
-		setMaxHealth(4);
 		super.onAttached();
+		setMaxHealth(10);
+		setHealth(10, HealthChangeReason.SPAWN);
 	}
 
 	@Override

--- a/src/main/java/org/spout/vanilla/controller/living/creature/passive/Mooshroom.java
+++ b/src/main/java/org/spout/vanilla/controller/living/creature/passive/Mooshroom.java
@@ -27,9 +27,17 @@
 package org.spout.vanilla.controller.living.creature.passive;
 
 import org.spout.vanilla.controller.VanillaControllerTypes;
+import org.spout.vanilla.controller.source.HealthChangeReason;
 
 public class Mooshroom extends Cow {
 	public Mooshroom() {
 		super(VanillaControllerTypes.MOOSHROOM);
+	}
+	
+	@Override
+	public void onAttached() {
+		super.onAttached();
+		setMaxHealth(10);
+		setHealth(10, HealthChangeReason.SPAWN);
 	}
 }

--- a/src/main/java/org/spout/vanilla/controller/living/creature/passive/Ocelot.java
+++ b/src/main/java/org/spout/vanilla/controller/living/creature/passive/Ocelot.java
@@ -43,17 +43,10 @@ public class Ocelot extends Creature implements Tameable, Passive {
 
 	@Override
 	public void onAttached() {
-		// TODO Check these values...
-		// master = data().get("controlling_entity", master);
-		if (master != null) {
-			setHealth(20, HealthChangeReason.SPAWN);
-			setMaxHealth(20);
-		} else {
-			setHealth(8, HealthChangeReason.SPAWN);
-			setMaxHealth(8);
-		}
-
 		super.onAttached();
+		setMaxHealth(10);
+		setHealth(10, HealthChangeReason.SPAWN);
+		// master = data().get("controlling_entity", master);
 	}
 
 	@Override

--- a/src/main/java/org/spout/vanilla/controller/living/creature/passive/Pig.java
+++ b/src/main/java/org/spout/vanilla/controller/living/creature/passive/Pig.java
@@ -47,9 +47,9 @@ public class Pig extends Creature implements Passive {
 
 	@Override
 	public void onAttached() {
-		setHealth(10, HealthChangeReason.SPAWN);
-		setMaxHealth(10);
 		super.onAttached();
+		setMaxHealth(10);
+		setHealth(10, HealthChangeReason.SPAWN);
 	}
 
 	@Override

--- a/src/main/java/org/spout/vanilla/controller/living/creature/passive/Sheep.java
+++ b/src/main/java/org/spout/vanilla/controller/living/creature/passive/Sheep.java
@@ -52,11 +52,11 @@ public class Sheep extends Creature implements Passive {
 
 	@Override
 	public void onAttached() {
-		setHealth(8, HealthChangeReason.SPAWN);
+		super.onAttached();
 		setMaxHealth(8);
+		setHealth(8, HealthChangeReason.SPAWN);
 		final SheepEatGrassLogic eatGrassLogic = new SheepEatGrassLogic(this);
 		registerProcess(eatGrassLogic);
-		super.onAttached();
 		isSheared = data().get("sheep_sheared", false);
 		sheepColor = data().get("sheep_color", (short) 0);
 	}

--- a/src/main/java/org/spout/vanilla/controller/living/creature/passive/Squid.java
+++ b/src/main/java/org/spout/vanilla/controller/living/creature/passive/Squid.java
@@ -46,9 +46,9 @@ public class Squid extends Creature implements Passive {
 
 	@Override
 	public void onAttached() {
-		setHealth(10, HealthChangeReason.SPAWN);
-		setMaxHealth(10);
 		super.onAttached();
+		setMaxHealth(10);
+		setHealth(10, HealthChangeReason.SPAWN);
 	}
 
 	@Override

--- a/src/main/java/org/spout/vanilla/controller/living/creature/passive/Villager.java
+++ b/src/main/java/org/spout/vanilla/controller/living/creature/passive/Villager.java
@@ -38,8 +38,8 @@ public class Villager extends Creature implements Passive {
 
 	@Override
 	public void onAttached() {
-		setHealth(20, HealthChangeReason.SPAWN);
-		setMaxHealth(20);
 		super.onAttached();
+		setMaxHealth(20);
+		setHealth(20, HealthChangeReason.SPAWN);
 	}
 }


### PR DESCRIPTION
All creature healths was at 1 because of the super.onAttached() being called after and also because of setMaxHealth being set after setting the health.

This pull fix this issue.
