### PR TITLE
Fixed death animation & Minecart health

### DIFF
--- a/src/main/java/org/spout/vanilla/controller/VanillaActionController.java
+++ b/src/main/java/org/spout/vanilla/controller/VanillaActionController.java
@@ -128,9 +128,6 @@ public abstract class VanillaActionController extends Controller implements Vani
 	@Override
 	public void onTick(float dt) {
 		if (deathTicks > 0) {
-			if (getHealth() > 0) {
-				deathTicks = 0;
-			} else {
 				deathTicks--;
 				if (deathTicks == 0) {
 					if (this instanceof PlayerController) {
@@ -140,14 +137,20 @@ public abstract class VanillaActionController extends Controller implements Vani
 					}
 				}
 				return;
-			}
 		}
 		updateFireTicks();
 
 		// Check controller health, send messages to the client based on current state.
 		if (health <= 0) {
-			VanillaNetworkUtil.broadcastPacket(new EntityStatusMessage(getParent().getId(), EntityStatusMessage.ENTITY_DEAD));
-			deathTicks = 30;
+			if (type.equals(VanillaControllerTypes.MINECART)){
+				getParent().kill();
+				
+			}
+			else {
+				VanillaNetworkUtil.broadcastPacket(new EntityStatusMessage(getParent().getId(), EntityStatusMessage.ENTITY_DEAD));
+				deathTicks = 30;
+			}
+			
 			onDeath();
 		}
 
@@ -513,9 +516,8 @@ public abstract class VanillaActionController extends Controller implements Vani
 		if (!event.isCancelled()) {
 			if (event.getChange() > maxHealth) {
 				this.health = maxHealth;
-			} else if (event.getChange() <= 0) {
-				this.getParent().kill();
-			} else {
+			}
+			else {
 				this.health = event.getChange();
 			}
 		}

--- a/src/main/java/org/spout/vanilla/controller/object/vehicle/Minecart.java
+++ b/src/main/java/org/spout/vanilla/controller/object/vehicle/Minecart.java
@@ -47,6 +47,7 @@ public abstract class Minecart extends Substance implements Vehicle {
 	private Material blockType = VanillaMaterials.AIR;
 	private RailBase railMaterial;
 	private RailsState railState;
+	private int regentick = 0;
 	private Vector3 groundFrictionModifier = new Vector3(0.5, 0.5, 0.5);
 	private Vector3 airFrictionModifier = new Vector3(0.95, 0.95, 0.95);
 	private Vector2[] railMovement = new Vector2[]{Vector2.ZERO, Vector2.ZERO};
@@ -83,7 +84,8 @@ public abstract class Minecart extends Substance implements Vehicle {
 		this.getBounds().set(-0.35f, 0.0f, -0.49f, 0.35f, 0.49f, 0.49f);
 		this.setVelocity(new Vector3(0, 0, 0.2)); //temporary!
 		this.setMaxSpeed(new Vector3(0.4, 0.4, 0.4)); //first two 0.4 need to be 0 - TODO: Use yaw instead?
-		setHealth(40, HealthChangeReason.SPAWN);
+		setMaxHealth(6);
+		setHealth(6, HealthChangeReason.SPAWN);
 	}
 
 	@Override
@@ -129,10 +131,15 @@ public abstract class Minecart extends Substance implements Vehicle {
 
 		//update health to regenerate
 		int health = getHealth();
-		if (health < 40) {
-			setHealth(health + 1, HealthChangeReason.REGENERATION);
+		if (health < 6) {
+			if (regentick >= 7) {
+				setHealth(health + 1, HealthChangeReason.REGENERATION);
+				regentick = 0;
+			}
+			else {
+				regentick++;
+			}
 		}
-
 		//get current rail below minecart
 		Point position = getParent().getPosition();
 		if (position.getWorld() == null) {


### PR DESCRIPTION
I fixed the Death animation on Entities and Minecart health. I added a tick in Minecart (7) so health is not insta-regen. It looks like the Vanilla speed.
