### PR TITLE
World chunk protocol update.

### DIFF
--- a/src/main/java/org/spout/vanilla/protocol/VanillaNetworkSynchronizer.java
+++ b/src/main/java/org/spout/vanilla/protocol/VanillaNetworkSynchronizer.java
@@ -273,7 +273,7 @@ public class VanillaNetworkSynchronizer extends NetworkSynchronizer implements P
 				}
 			}
 
-			CompressedChunkMessage CCMsg = new CompressedChunkMessage(x, z, true, new boolean[16], 0, packetChunkData, biomeData);
+			CompressedChunkMessage CCMsg = new CompressedChunkMessage(x, z, true, new boolean[16], packetChunkData, biomeData);
 			owner.getSession().send(false, CCMsg);
 		}
 
@@ -303,7 +303,7 @@ public class VanillaNetworkSynchronizer extends NetworkSynchronizer implements P
 
 		byte[][] packetChunkData = new byte[16][];
 		packetChunkData[y] = fullChunkData;
-		CompressedChunkMessage CCMsg = new CompressedChunkMessage(x, z, false, new boolean[16], 0, packetChunkData, null);
+		CompressedChunkMessage CCMsg = new CompressedChunkMessage(x, z, false, new boolean[16], packetChunkData, null);
 		owner.getSession().send(false, CCMsg);
 	}
 

--- a/src/main/java/org/spout/vanilla/protocol/bootstrap/handler/BootstrapEncryptionKeyResponseMessageHandler.java
+++ b/src/main/java/org/spout/vanilla/protocol/bootstrap/handler/BootstrapEncryptionKeyResponseMessageHandler.java
@@ -71,7 +71,6 @@ public class BootstrapEncryptionKeyResponseMessageHandler extends MessageHandler
 				kickInvalidUser(session);
 				return;
 			}
-
 			final byte[] savedValidateToken = (byte[]) session.getDataMap().get("verifytoken");
 
 			boolean equals = true;
@@ -93,12 +92,13 @@ public class BootstrapEncryptionKeyResponseMessageHandler extends MessageHandler
 
 			String handshakeUsername = session.getDataMap().get(VanillaProtocol.HANDSHAKE_USERNAME);
 			final String finalName = handshakeUsername.split(";")[0];
-			Thread loginAuth = new Thread(new LoginAuth(session, finalName, new PlayerConnectRunnable(session, finalName)));
+			Thread loginAuth = new Thread(new LoginAuth(session, finalName, null));
 			loginAuth.start();
 			while (loginAuth.isAlive()) {
 			}
 			// If we get in that if, it means the player is legit
 			if (session.isConnected()) {
+				
 				session.sendAll(false, true, new EncryptionKeyResponseMessage(new byte[0], false, new byte[0]));
 				return;
 
@@ -136,29 +136,5 @@ public class BootstrapEncryptionKeyResponseMessageHandler extends MessageHandler
 
 	private static void kickInvalidUser(Session session) {
 		session.disconnect(false, new Object[] { "Failed to verify username!" });
-	}
-
-	private static class PlayerConnectRunnable implements Runnable {
-		private final Session session;
-		private final String name;
-
-		private PlayerConnectRunnable(Session session, String name) {
-			this.session = session;
-			this.name = name;
-		}
-
-		@Override
-		public void run() {
-			BootstrapEncryptionKeyResponseMessageHandler.playerConnect(session, name);
-		}
-
-	}
-
-	public static void playerConnect(Session session, String name) {
-		Event event = new PlayerConnectEvent(session, name);
-		session.getEngine().getEventManager().callEvent(event);
-		if (Spout.getEngine().debugMode()) {
-			Spout.getLogger().info("Login took " + (System.currentTimeMillis() - session.getDataMap().get(VanillaProtocol.LOGIN_TIME)) + " ms");
-		}
 	}
 }

--- a/src/main/java/org/spout/vanilla/protocol/bootstrap/handler/BootstrapHandshakeMessageHandler.java
+++ b/src/main/java/org/spout/vanilla/protocol/bootstrap/handler/BootstrapHandshakeMessageHandler.java
@@ -26,18 +26,13 @@
  */
 package org.spout.vanilla.protocol.bootstrap.handler;
 
-import java.security.KeyPairGenerator;
-import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
-import java.util.Random;
 
-import org.bouncycastle.crypto.AsymmetricBlockCipher;
 import org.bouncycastle.crypto.AsymmetricCipherKeyPair;
 
 import org.spout.api.player.Player;
 import org.spout.api.protocol.MessageHandler;
 import org.spout.api.protocol.Session;
-import org.spout.api.protocol.Session.State;
 import org.spout.api.security.SecurityHandler;
 
 import org.spout.vanilla.VanillaPlugin;

--- a/src/main/java/org/spout/vanilla/protocol/bootstrap/handler/BootstrapLoginRequestMessageHandler.java
+++ b/src/main/java/org/spout/vanilla/protocol/bootstrap/handler/BootstrapLoginRequestMessageHandler.java
@@ -26,17 +26,10 @@
  */
 package org.spout.vanilla.protocol.bootstrap.handler;
 
-import org.spout.api.Spout;
-import org.spout.api.event.Event;
-import org.spout.api.event.player.PlayerConnectEvent;
 import org.spout.api.player.Player;
 import org.spout.api.protocol.MessageHandler;
 import org.spout.api.protocol.Session;
 
-import org.spout.vanilla.VanillaPlugin;
-import org.spout.vanilla.configuration.VanillaConfiguration;
-import org.spout.vanilla.protocol.VanillaProtocol;
-import org.spout.vanilla.protocol.bootstrap.handler.auth.LoginAuth;
 import org.spout.vanilla.protocol.msg.login.LoginRequestMessage;
 
 public class BootstrapLoginRequestMessageHandler extends MessageHandler<LoginRequestMessage> {

--- a/src/main/java/org/spout/vanilla/protocol/bootstrap/handler/auth/LoginAuth.java
+++ b/src/main/java/org/spout/vanilla/protocol/bootstrap/handler/auth/LoginAuth.java
@@ -109,7 +109,10 @@ public class LoginAuth implements Runnable {
 			in = new BufferedReader(new InputStreamReader(httpConnection.getInputStream()));
 			String reply = in.readLine();
 			if (authString.equals(reply)) {
-				Spout.getEngine().getScheduler().scheduleSyncDelayedTask(VanillaPlugin.getInstance(), runnable, TaskPriority.CRITICAL);
+				if (runnable != null) {
+					Spout.getEngine().getScheduler().scheduleSyncDelayedTask(VanillaPlugin.getInstance(), runnable, TaskPriority.CRITICAL);
+				}
+				
 			} else {
 				failed("Auth server refused authentication");
 			}

--- a/src/main/java/org/spout/vanilla/protocol/codec/CompressedChunkCodec.java
+++ b/src/main/java/org/spout/vanilla/protocol/codec/CompressedChunkCodec.java
@@ -56,7 +56,6 @@ public final class CompressedChunkCodec extends MessageCodec<CompressedChunkMess
 		short primaryBitMap = buffer.readShort();
 		short addBitMap = buffer.readShort();
 		int compressedSize = buffer.readInt();
-		int unused = buffer.readInt();
 		byte[] compressedData = new byte[compressedSize];
 		buffer.readBytes(compressedData);
 
@@ -119,7 +118,7 @@ public final class CompressedChunkCodec extends MessageCodec<CompressedChunkMess
 			size += biomeData.length;
 		}
 
-		return new CompressedChunkMessage(x, z, contiguous, hasAdditionalData, unused, data, biomeData);
+		return new CompressedChunkMessage(x, z, contiguous, hasAdditionalData, data, biomeData);
 	}
 
 	@Override
@@ -181,7 +180,6 @@ public final class CompressedChunkCodec extends MessageCodec<CompressedChunkMess
 		}
 
 		buffer.writeInt(compressed);
-		buffer.writeInt(message.getUnused());
 		buffer.writeBytes(compressedData, 0, compressed);
 
 		return buffer;

--- a/src/main/java/org/spout/vanilla/protocol/codec/EncryptionKeyRequestCodec.java
+++ b/src/main/java/org/spout/vanilla/protocol/codec/EncryptionKeyRequestCodec.java
@@ -48,7 +48,7 @@ public final class EncryptionKeyRequestCodec extends MessageCodec<EncryptionKeyR
 		int tokenLength = buffer.readShort() &0xFFFF;
 		byte[] token = new byte[tokenLength];
 		buffer.readBytes(token);
-		return new EncryptionKeyRequestMessage(sessionId, publicKey, true, token);
+		return new EncryptionKeyRequestMessage(sessionId, publicKey, false, token);
 	}
 
 	@Override

--- a/src/main/java/org/spout/vanilla/protocol/codec/EncryptionKeyResponseCodec.java
+++ b/src/main/java/org/spout/vanilla/protocol/codec/EncryptionKeyResponseCodec.java
@@ -46,7 +46,7 @@ public class EncryptionKeyResponseCodec extends MessageCodec<EncryptionKeyRespon
 		int validateTokenLength = buffer.readShort() & 0xFFFF;
 		byte[] validateToken = new byte[validateTokenLength];
 		buffer.readBytes(validateToken);
-		return new EncryptionKeyResponseMessage(encoded, true, validateToken);
+		return new EncryptionKeyResponseMessage(encoded, false, validateToken);
 	}
 
 	@Override

--- a/src/main/java/org/spout/vanilla/protocol/handler/ClientStatusHandler.java
+++ b/src/main/java/org/spout/vanilla/protocol/handler/ClientStatusHandler.java
@@ -27,16 +27,36 @@
 package org.spout.vanilla.protocol.handler;
 
 import org.spout.api.Spout;
+import org.spout.api.event.Event;
+import org.spout.api.event.player.PlayerConnectEvent;
+import org.spout.api.geo.World;
 import org.spout.api.player.Player;
 import org.spout.api.protocol.MessageHandler;
 import org.spout.api.protocol.Session;
+import org.spout.vanilla.data.VanillaData;
+import org.spout.vanilla.protocol.VanillaProtocol;
 import org.spout.vanilla.protocol.msg.ClientStatusMessage;
+import org.spout.vanilla.protocol.msg.login.request.ServerLoginRequestMessage;
 
 public class ClientStatusHandler extends MessageHandler<ClientStatusMessage> {
-    @Override
-    public void handleServer(Session session, Player player, ClientStatusMessage message) {
-        //TODO Do we handle anything? Should we send chunks when the client says "I am a'okay to log in?", what does "I am a'okay to login even mean?"
-        //For now lets print out when the client sends it
-        Spout.log("Client sent: " + message.toString());
-    }
+	@Override
+	public void handleServer(Session session, Player player, ClientStatusMessage message) {
+		// TODO Do we handle anything? Should we send chunks when the client says "I am a'okay to log in?", what does "I am a'okay to login even mean?"
+		// For now lets print out when the client sends it
+		Spout.log("Client sent: " + message.toString());
+		World world = Spout.getEngine().getWorlds().iterator().next();
+		if (message.getStatus() == ClientStatusMessage.INITIAL_SPAWN) {
+			session.send(false, new ServerLoginRequestMessage(player.getEntity().getId(), world.getDataMap().get(VanillaData.WORLD_TYPE).name(), world.getDataMap().get(VanillaData.GAMEMODE).getId(), (byte) world.getDataMap().get(VanillaData.DIMENSION).getId(), world.getDataMap().get(VanillaData.DIFFICULTY).getId(), (short) Spout.getEngine().getMaxPlayers()));
+			playerConnect(session, player.getName());
+		}
+
+	}
+
+	public static void playerConnect(Session session, String name) {
+		Event event = new PlayerConnectEvent(session, name);
+		session.getEngine().getEventManager().callEvent(event);
+		if (Spout.getEngine().debugMode()) {
+			Spout.getLogger().info("Login took " + (System.currentTimeMillis() - session.getDataMap().get(VanillaProtocol.LOGIN_TIME)) + " ms");
+		}
+	}
 }

--- a/src/main/java/org/spout/vanilla/protocol/msg/CompressedChunkMessage.java
+++ b/src/main/java/org/spout/vanilla/protocol/msg/CompressedChunkMessage.java
@@ -35,11 +35,10 @@ public final class CompressedChunkMessage extends Message {
 	private final int x, z;
 	private final boolean contiguous;
 	private final boolean[] hasAdditionalData;
-	private final int unused;
 	private final byte[][] data;
 	private final byte[] biomeData;
 
-	public CompressedChunkMessage(int x, int z, boolean contiguous, boolean[] hasAdditionalData, int unused, byte[][] data, byte[] biomeData) {
+	public CompressedChunkMessage(int x, int z, boolean contiguous, boolean[] hasAdditionalData, byte[][] data, byte[] biomeData) {
 		if (hasAdditionalData.length != data.length || data.length != 16) {
 			throw new IllegalArgumentException("Data and hasAdditionalData must have a length of 16");
 		}
@@ -47,7 +46,6 @@ public final class CompressedChunkMessage extends Message {
 		this.z = z;
 		this.contiguous = contiguous;
 		this.hasAdditionalData = hasAdditionalData;
-		this.unused = unused;
 		this.data = data;
 		this.biomeData = biomeData;
 	}
@@ -68,10 +66,6 @@ public final class CompressedChunkMessage extends Message {
 		return contiguous;
 	}
 
-	public int getUnused() {
-		return unused;
-	}
-
 	public byte[][] getData() {
 		return data;
 	}
@@ -87,7 +81,6 @@ public final class CompressedChunkMessage extends Message {
 				.append("z", z)
 				.append("hasAdditionalData", hasAdditionalData)
 				.append("contiguous", contiguous)
-				.append("unusedValue", unused)
 				.append("data", data, false)
 				.append("biomeData", data, false)
 				.toString();
@@ -107,7 +100,6 @@ public final class CompressedChunkMessage extends Message {
 				.append(this.z, other.z)
 				.append(this.contiguous, other.contiguous)
 				.append(this.hasAdditionalData, other.hasAdditionalData)
-				.append(this.unused, other.unused)
 				.append(this.data, other.data)
 				.append(this.biomeData, other.biomeData)
 				.isEquals();

--- a/src/test/java/org/spout/vanilla/protocol/VanillaProtocolTest.java
+++ b/src/test/java/org/spout/vanilla/protocol/VanillaProtocolTest.java
@@ -157,7 +157,7 @@ public class VanillaProtocolTest extends BaseProtocolTest {
 			new EntityRemoveEffectMessage(1, (byte) 1),
 			new SetExperienceMessage(1.2F, (short) 2, (short) 3),
 			new LoadChunkMessage(0, -2, true),
-			new CompressedChunkMessage(1, 2, true, new boolean[16], 1, new byte[][]{new byte[16 * 16 * 16 * 5 / 2], null, null, null, null, null, null, null, null, null, new byte[Chunk.BLOCKS.HALF_VOLUME * 5], null, null, null, null, null}, new byte[16 * 16]),
+			new CompressedChunkMessage(1, 2, true, new boolean[16], new byte[][]{new byte[16 * 16 * 16 * 5 / 2], null, null, null, null, null, null, null, null, null, new byte[Chunk.BLOCKS.HALF_VOLUME * 5], null, null, null, null, null}, new byte[16 * 16]),
 			new MultiBlockChangeMessage(2, 3, new short[]{2, 3, 4, /**/ 3, 6, 4, /**/ 8, 5, 5}, new short[]{1, 2, 3}, new byte[]{3, 4, 5}),
 			new BlockChangeMessage(1, 2, 3, 87, 2),
 			new BlockActionMessage(1, 2, 3, (byte) 4, (byte) 5, (byte) 29),


### PR DESCRIPTION
PlayerConnect area modification. Doesn't spam error now..

Players can't connect yet due to a error similar to:

`01:22:26 [AVERTISSEMENT] Exception caught, closing channel: [id: 0x014dcd45, /12
7.0.0.1:53396 => /127.0.0.1:25565]...
java.io.IOException: Unknown operation code: 34437 (previous opcodes: 0, 0, 0, 0
, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
227).
        at org.spout.api.protocol.CommonDecoder.decodeProcessed(CommonDecoder.ja
va:93)
        at org.spout.api.protocol.PreprocessReplayingDecoder.decode(PreprocessRe
playingDecoder.java:99)
        at org.jboss.netty.handler.codec.frame.FrameDecoder.callDecode(FrameDeco
der.java:328)
        at org.jboss.netty.handler.codec.frame.FrameDecoder.messageReceived(Fram
eDecoder.java:211)
        at org.jboss.netty.channel.Channels.fireMessageReceived(Channels.java:26
8)
        at org.jboss.netty.channel.Channels.fireMessageReceived(Channels.java:25
5)
        at org.jboss.netty.channel.socket.nio.NioWorker.read(NioWorker.java:94)
        at org.jboss.netty.channel.socket.nio.AbstractNioWorker.processSelectedK
eys(AbstractNioWorker.java:372)
        at org.jboss.netty.channel.socket.nio.AbstractNioWorker.run(AbstractNioW
orker.java:246)
        at org.jboss.netty.channel.socket.nio.NioWorker.run(NioWorker.java:38)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
        at java.lang.Thread.run(Unknown Source)`

It happens right after sending the empty Encryption Key Response (0xFC) 
