### PR TITLE
Fixed many block drops to match Vanilla gameplay.

### DIFF
--- a/src/main/java/org/spout/vanilla/material/block/ore/CoalOre.java
+++ b/src/main/java/org/spout/vanilla/material/block/ore/CoalOre.java
@@ -44,7 +44,9 @@ public class CoalOre extends Ore implements TimedCraftable, InitializableMateria
 
 	@Override
 	public void initialize() {
-		this.getDrops().add(VanillaMaterials.COAL_ORE);
+		getDrops().clear();
+		getDrops().DEFAULT.add(VanillaMaterials.COAL);
+		getDrops().SILK_TOUCH.add(VanillaMaterials.COAL_ORE);
 	}
 
 	@Override

--- a/src/main/java/org/spout/vanilla/material/block/ore/DiamondOre.java
+++ b/src/main/java/org/spout/vanilla/material/block/ore/DiamondOre.java
@@ -44,7 +44,9 @@ public class DiamondOre extends Ore implements InitializableMaterial, TimedCraft
 
 	@Override
 	public void initialize() {
-		this.getDrops().add(VanillaMaterials.DIAMOND);
+		getDrops().clear();
+		getDrops().DEFAULT.add(VanillaMaterials.DIAMOND);
+		getDrops().SILK_TOUCH.add(VanillaMaterials.DIAMOND_ORE);
 	}
 
 	@Override

--- a/src/main/java/org/spout/vanilla/material/block/ore/EmeraldOre.java
+++ b/src/main/java/org/spout/vanilla/material/block/ore/EmeraldOre.java
@@ -44,7 +44,9 @@ public class EmeraldOre extends Ore implements InitializableMaterial, TimedCraft
 
 	@Override
 	public void initialize() {
-		this.getDrops().add(VanillaMaterials.EMERALD);
+		getDrops().clear();
+		getDrops().DEFAULT.add(VanillaMaterials.EMERALD);
+		getDrops().SILK_TOUCH.add(VanillaMaterials.EMERALD_ORE);
 	}
 
 	@Override

--- a/src/main/java/org/spout/vanilla/material/block/ore/LapisLazuliOre.java
+++ b/src/main/java/org/spout/vanilla/material/block/ore/LapisLazuliOre.java
@@ -30,6 +30,7 @@ import org.spout.api.inventory.ItemStack;
 
 import org.spout.vanilla.material.InitializableMaterial;
 import org.spout.vanilla.material.TimedCraftable;
+import org.spout.vanilla.material.VanillaMaterials;
 import org.spout.vanilla.material.block.Ore;
 import org.spout.vanilla.material.block.controlled.FurnaceBlock;
 import org.spout.vanilla.material.item.misc.Dye;
@@ -44,7 +45,9 @@ public class LapisLazuliOre extends Ore implements TimedCraftable, Initializable
 
 	@Override
 	public void initialize() {
-		this.getDrops().addRange(Dye.LAPIS_LAZULI, 2, 4);
+		getDrops().clear();
+		getDrops().DEFAULT.addRange(Dye.LAPIS_LAZULI, 2, 4);
+		getDrops().SILK_TOUCH.add(VanillaMaterials.LAPIS_LAZULI_ORE);
 	}
 
 	@Override

--- a/src/main/java/org/spout/vanilla/material/block/ore/MelonBlock.java
+++ b/src/main/java/org/spout/vanilla/material/block/ore/MelonBlock.java
@@ -38,6 +38,8 @@ public class MelonBlock extends Ore implements InitializableMaterial {
 
 	@Override
 	public void initialize() {
-		this.getDrops().addRange(VanillaMaterials.MELON_SLICE, 1, 3);
+		getDrops().clear();
+		getDrops().DEFAULT.addRange(VanillaMaterials.MELON_SLICE, 1, 3);
+		getDrops().SILK_TOUCH.add(VanillaMaterials.MELON_BLOCK);
 	}
 }

--- a/src/main/java/org/spout/vanilla/material/block/ore/RedstoneOre.java
+++ b/src/main/java/org/spout/vanilla/material/block/ore/RedstoneOre.java
@@ -47,7 +47,9 @@ public class RedstoneOre extends Ore implements TimedCraftable, InitializableMat
 
 	@Override
 	public void initialize() {
-		this.getDrops().add(VanillaMaterials.REDSTONE_DUST, 4);
+		getDrops().clear();
+		getDrops().add(VanillaMaterials.REDSTONE_DUST, 4);
+		getDrops().SILK_TOUCH.add(VanillaMaterials.REDSTONE_ORE);
 	}
 
 	@Override

--- a/src/main/java/org/spout/vanilla/material/block/solid/ClayBlock.java
+++ b/src/main/java/org/spout/vanilla/material/block/solid/ClayBlock.java
@@ -41,6 +41,7 @@ public class ClayBlock extends Solid implements InitializableMaterial {
 
 	@Override
 	public void initialize() {
-		this.getDrops().DEFAULT.clear().add(VanillaMaterials.CLAY, 4);
+		getDrops().DEFAULT.clear().add(VanillaMaterials.CLAY, 4);
+		getDrops().SILK_TOUCH.add(VanillaMaterials.CLAY_BLOCK);
 	}
 }

--- a/src/main/java/org/spout/vanilla/material/block/solid/Grass.java
+++ b/src/main/java/org/spout/vanilla/material/block/solid/Grass.java
@@ -46,7 +46,9 @@ public class Grass extends SpreadingSolid implements RandomBlockMaterial, Initia
 	@Override
 	public void initialize() {
 		this.setReplacedMaterial(VanillaMaterials.DIRT);
-		this.getDrops().add(VanillaMaterials.DIRT);
+		getDrops().DEFAULT.clear();	
+		getDrops().DEFAULT.add(VanillaMaterials.DIRT);
+		getDrops().SILK_TOUCH.add(VanillaMaterials.GRASS);
 	}
 
 	@Override

--- a/src/main/java/org/spout/vanilla/material/block/solid/Ice.java
+++ b/src/main/java/org/spout/vanilla/material/block/solid/Ice.java
@@ -56,7 +56,8 @@ public class Ice extends SpreadingSolid implements InitializableMaterial {
 
 	@Override
 	public void initialize() {
-		this.setReplacedMaterial(VanillaMaterials.WATER);
+		setReplacedMaterial(VanillaMaterials.WATER);
+		getDrops().DEFAULT.clear();
 	}
 
 	@Override

--- a/src/main/java/org/spout/vanilla/material/block/solid/MushroomBlock.java
+++ b/src/main/java/org/spout/vanilla/material/block/solid/MushroomBlock.java
@@ -45,9 +45,12 @@ public class MushroomBlock extends Solid implements Fuel, InitializableMaterial 
 		getDrops().DEFAULT.clear();
 		if (this.equals(VanillaMaterials.HUGE_RED_MUSHROOM)) {
 			getDrops().DEFAULT.addRange(VanillaMaterials.RED_MUSHROOM, -7, 2);
+			getDrops().SILK_TOUCH.add(VanillaMaterials.HUGE_RED_MUSHROOM);
 		} else {
 			getDrops().DEFAULT.addRange(VanillaMaterials.BROWN_MUSHROOM, -7, 2);
+			getDrops().SILK_TOUCH.add(VanillaMaterials.HUGE_BROWN_MUSHROOM);
 		}
+		
 	}
 
 	@Override

--- a/src/main/java/org/spout/vanilla/material/block/solid/Mycelium.java
+++ b/src/main/java/org/spout/vanilla/material/block/solid/Mycelium.java
@@ -42,8 +42,10 @@ public class Mycelium extends SpreadingSolid implements InitializableMaterial {
 
 	@Override
 	public void initialize() {
-		this.setReplacedMaterial(VanillaMaterials.DIRT);
-		this.getDrops().add(VanillaMaterials.DIRT);
+		setReplacedMaterial(VanillaMaterials.DIRT);
+		getDrops().DEFAULT.clear();
+		getDrops().DEFAULT.add(VanillaMaterials.DIRT);
+		getDrops().SILK_TOUCH.add(VanillaMaterials.MYCELIUM);
 	}
 
 	@Override

--- a/src/main/java/org/spout/vanilla/material/block/solid/Stone.java
+++ b/src/main/java/org/spout/vanilla/material/block/solid/Stone.java
@@ -42,6 +42,7 @@ public class Stone extends Solid implements InitializableMaterial {
 	@Override
 	public void initialize() {
 		this.getDrops().DEFAULT.clear().add(VanillaMaterials.COBBLESTONE);
+		this.getDrops().SILK_TOUCH.add(VanillaMaterials.STONE);
 	}
 
 	@Override


### PR DESCRIPTION
Many common items, such as grass, did not clear the default drop table
before adding their actual drop (dirt in grass's case) I fixed such
errors where neccesary, and added approprate drop "clear" and "add"
methods to all of the files in this commit (including adding special
VanillaMaterials for SilkTouch, may have missed a few, check).

Signed-off-by: Raymond Beehler 21GunSoftware@comcast.net
