### PR TITLE
Rewrite of the entity protocols and added network comps

### DIFF
--- a/src/main/java/org/spout/vanilla/entity/component/PositionUpdateOwner.java
+++ b/src/main/java/org/spout/vanilla/entity/component/PositionUpdateOwner.java
@@ -24,25 +24,16 @@
  * License and see <http://www.spout.org/SpoutDevLicenseV1.txt> for the full license,
  * including the MIT license.
  */
-package org.spout.vanilla.protocol.entity.object;
+package org.spout.vanilla.entity.component;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
+import org.spout.vanilla.entity.component.network.PositionUpdateComponent;
 
-import org.spout.api.entity.Entity;
-import org.spout.api.protocol.Message;
+public interface PositionUpdateOwner extends ComponentOwner {
 
-import org.spout.vanilla.entity.object.misc.Lightning;
-import org.spout.vanilla.protocol.entity.VanillaEntityProtocol;
-import org.spout.vanilla.protocol.msg.entity.EntitySpawnLightningStrikeMessage;
-
-public class LightningEntityProtocol extends VanillaEntityProtocol {
-	@Override
-	public List<Message> getSpawnMessages(Entity entity) {
-		if (!(entity.getController() instanceof Lightning)) {
-			return Collections.emptyList();
-		}
-		return Arrays.<Message>asList(new EntitySpawnLightningStrikeMessage(entity.getId(), entity.getPosition().getBlockX(), entity.getPosition().getBlockY(), entity.getPosition().getBlockZ()));
-	}
+	/**
+	 * Gets the position-updateable network component of this Entity
+	 * 
+	 * @return network component
+	 */
+	public PositionUpdateComponent<?> getNetworkComponent();
 }

--- a/src/main/java/org/spout/vanilla/entity/component/network/EntityNetworkComponent.java
+++ b/src/main/java/org/spout/vanilla/entity/component/network/EntityNetworkComponent.java
@@ -24,25 +24,15 @@
  * License and see <http://www.spout.org/SpoutDevLicenseV1.txt> for the full license,
  * including the MIT license.
  */
-package org.spout.vanilla.protocol.entity.object;
+package org.spout.vanilla.entity.component.network;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
+import org.spout.api.tickable.TickPriority;
+import org.spout.vanilla.entity.VanillaEntityController;
 
-import org.spout.api.entity.Entity;
-import org.spout.api.protocol.Message;
+public class EntityNetworkComponent extends PositionUpdateComponent<VanillaEntityController> {
 
-import org.spout.vanilla.entity.object.misc.Lightning;
-import org.spout.vanilla.protocol.entity.VanillaEntityProtocol;
-import org.spout.vanilla.protocol.msg.entity.EntitySpawnLightningStrikeMessage;
-
-public class LightningEntityProtocol extends VanillaEntityProtocol {
-	@Override
-	public List<Message> getSpawnMessages(Entity entity) {
-		if (!(entity.getController() instanceof Lightning)) {
-			return Collections.emptyList();
-		}
-		return Arrays.<Message>asList(new EntitySpawnLightningStrikeMessage(entity.getId(), entity.getPosition().getBlockX(), entity.getPosition().getBlockY(), entity.getPosition().getBlockZ()));
+	public EntityNetworkComponent(TickPriority priority) {
+		super(priority);
 	}
+
 }

--- a/src/main/java/org/spout/vanilla/entity/object/Projectile.java
+++ b/src/main/java/org/spout/vanilla/entity/object/Projectile.java
@@ -48,10 +48,7 @@ public class Projectile extends Substance {
 
 	@Override
 	public void onAttached() {
-		Vector3 rotation = this.rotation.getAxisAngles();
-		yaw(rotation.getX());
-		pitch(rotation.getY());
-		roll(rotation.getZ());
+		getParent().setRotation(this.rotation);
 	}
 
 	@Override

--- a/src/main/java/org/spout/vanilla/protocol/VanillaNetworkSynchronizer.java
+++ b/src/main/java/org/spout/vanilla/protocol/VanillaNetworkSynchronizer.java
@@ -392,60 +392,27 @@ public class VanillaNetworkSynchronizer extends NetworkSynchronizer implements P
 	}
 
 	@Override
-	public void spawnEntity(Entity e) {
-		if (e == null) {
-			return;
-		}
-
+	public void syncEntity(Entity e, boolean spawn, boolean destroy, boolean update) {
 		Controller c = e.getController();
 		if (c != null) {
 			EntityProtocol ep = c.getType().getEntityProtocol(VanillaPlugin.VANILLA_PROTOCOL_ID);
 			if (ep != null) {
-				Message[] spawn = ep.getSpawnMessage(e);
-				if (spawn != null) {
-					session.sendAll(false, spawn);
+				List<Message> messages = new ArrayList<Message>(3);
+				// Sync using vanilla protocol
+				if (destroy) {
+					messages.addAll(ep.getDestroyMessages(e));
+				}
+				if (spawn) {
+					messages.addAll(ep.getSpawnMessages(e));
+				}
+				if (update) {
+					messages.addAll(ep.getUpdateMessages(e));
+				}
+				for (Message message : messages) {
+					this.session.send(false, message);
 				}
 			}
 		}
-		super.spawnEntity(e);
-	}
-
-	@Override
-	public void destroyEntity(Entity e) {
-		if (e == null) {
-			return;
-		}
-
-		Controller c = e.getController();
-		if (c != null) {
-			EntityProtocol ep = c.getType().getEntityProtocol(VanillaPlugin.VANILLA_PROTOCOL_ID);
-			if (ep != null) {
-				Message[] death = ep.getDestroyMessage(e);
-				if (death != null) {
-					session.sendAll(false, death);
-				}
-			}
-		}
-		super.destroyEntity(e);
-	}
-
-	@Override
-	public void syncEntity(Entity e) {
-		if (e == null) {
-			return;
-		}
-
-		Controller c = e.getController();
-		if (c != null) {
-			EntityProtocol ep = c.getType().getEntityProtocol(VanillaPlugin.VANILLA_PROTOCOL_ID);
-			if (ep != null) {
-				Message[] sync = ep.getUpdateMessage(e);
-				if (sync != null) {
-					session.sendAll(false, sync);
-				}
-			}
-		}
-		super.syncEntity(e);
 	}
 
 	@EventHandler

--- a/src/main/java/org/spout/vanilla/protocol/entity/BasicMobEntityProtocol.java
+++ b/src/main/java/org/spout/vanilla/protocol/entity/BasicMobEntityProtocol.java
@@ -28,6 +28,7 @@ package org.spout.vanilla.protocol.entity;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import org.spout.api.entity.Controller;
@@ -62,10 +63,10 @@ public class BasicMobEntityProtocol extends BasicEntityProtocol {
 	}
 
 	@Override
-	public Message[] getSpawnMessage(Entity entity) {
+	public List<Message> getSpawnMessages(Entity entity) {
 		Controller c = entity.getController();
 		if (c == null) {
-			return null;
+			return Collections.emptyList();
 		}
 
 		int id = entity.getId();
@@ -78,19 +79,16 @@ public class BasicMobEntityProtocol extends BasicEntityProtocol {
 		}
 		List<Parameter<?>> parameters = this.getSpawnParameters(c);
 		//TODO: Is there a Velocity in a entity class?
-		return new Message[]{new EntitySpawnMobMessage(id, this.getSpawnID(), pos, r, p, headyaw, (short) 0, (short) 0, (short) 0, parameters)};
+		return Arrays.<Message>asList(new EntitySpawnMobMessage(id, this.getSpawnID(), pos, r, p, headyaw, (short) 0, (short) 0, (short) 0, parameters));
 	}
 
 	@Override
-	public Message[] getUpdateMessage(Entity entity) {
+	public List<Message> getUpdateMessages(Entity entity) {
+		List<Message> messages = new ArrayList<Message>(super.getUpdateMessages(entity));
 		List<Parameter<?>> params = this.getSpawnParameters(entity.getController());
-		if (params == null || params.size() <= 0) {
-			return super.getUpdateMessage(entity);
+		if (params != null && !params.isEmpty()) {
+			messages.add(new EntityMetadataMessage(entity.getId(), params));
 		}
-
-		Message[] toSend = super.getUpdateMessage(entity);
-		List<Message> msgs = new ArrayList<Message>(Arrays.asList(toSend != null ? toSend : new Message[0]));
-		msgs.add(new EntityMetadataMessage(entity.getId(), params));
-		return msgs.toArray(new Message[msgs.size()]);
+		return messages;
 	}
 }

--- a/src/main/java/org/spout/vanilla/protocol/entity/BasicObjectEntityProtocol.java
+++ b/src/main/java/org/spout/vanilla/protocol/entity/BasicObjectEntityProtocol.java
@@ -26,6 +26,10 @@
  */
 package org.spout.vanilla.protocol.entity;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 import org.spout.api.entity.Controller;
 import org.spout.api.entity.Entity;
 import org.spout.api.protocol.Message;
@@ -38,13 +42,11 @@ public class BasicObjectEntityProtocol extends BasicEntityProtocol {
 	}
 
 	@Override
-	public Message[] getSpawnMessage(Entity entity) {
+	public List<Message> getSpawnMessages(Entity entity) {
 		Controller c = entity.getController();
 		if (c == null) {
-			return null;
+			return Collections.emptyList();
 		}
-
-		int id = entity.getId();
-		return new Message[]{new EntitySpawnVehicleMessage(id, this.getSpawnID(), entity.getPosition())};
+		return Arrays.<Message>asList(new EntitySpawnVehicleMessage(entity.getId(), this.getSpawnID(), entity.getPosition()));
 	}
 }

--- a/src/main/java/org/spout/vanilla/protocol/entity/BasicProjectileEntityProtocol.java
+++ b/src/main/java/org/spout/vanilla/protocol/entity/BasicProjectileEntityProtocol.java
@@ -26,6 +26,10 @@
  */
 package org.spout.vanilla.protocol.entity;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 import org.spout.api.entity.Controller;
 import org.spout.api.entity.Entity;
 import org.spout.api.protocol.Message;
@@ -39,10 +43,10 @@ public class BasicProjectileEntityProtocol extends BasicEntityProtocol {
 	}
 
 	@Override
-	public Message[] getSpawnMessage(Entity entity) {
+	public List<Message> getSpawnMessages(Entity entity) {
 		Controller c = entity.getController();
 		if (c == null || !(c instanceof Projectile)) {
-			return null;
+			return Collections.emptyList();
 		}
 
 		Projectile pro = (Projectile) c;
@@ -51,7 +55,6 @@ public class BasicProjectileEntityProtocol extends BasicEntityProtocol {
 
 		Entity shooter = pro.getShooter();
 		int shooterid = shooter == null ? 0 : shooter.getId();
-
-		return new Message[]{new EntitySpawnVehicleMessage(id, this.getSpawnID(), entity.getPosition(), shooterid, pro.getVelocity())};
+		return Arrays.<Message>asList(new EntitySpawnVehicleMessage(id, this.getSpawnID(), entity.getPosition(), shooterid, pro.getVelocity()));
 	}
 }

--- a/src/main/java/org/spout/vanilla/protocol/entity/PositionUpdateProtocol.java
+++ b/src/main/java/org/spout/vanilla/protocol/entity/PositionUpdateProtocol.java
@@ -24,25 +24,10 @@
  * License and see <http://www.spout.org/SpoutDevLicenseV1.txt> for the full license,
  * including the MIT license.
  */
-package org.spout.vanilla.protocol.entity.object;
+package org.spout.vanilla.protocol.entity;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
+import org.spout.api.protocol.EntityProtocol;
 
-import org.spout.api.entity.Entity;
-import org.spout.api.protocol.Message;
+public abstract class PositionUpdateProtocol implements EntityProtocol {
 
-import org.spout.vanilla.entity.object.misc.Lightning;
-import org.spout.vanilla.protocol.entity.VanillaEntityProtocol;
-import org.spout.vanilla.protocol.msg.entity.EntitySpawnLightningStrikeMessage;
-
-public class LightningEntityProtocol extends VanillaEntityProtocol {
-	@Override
-	public List<Message> getSpawnMessages(Entity entity) {
-		if (!(entity.getController() instanceof Lightning)) {
-			return Collections.emptyList();
-		}
-		return Arrays.<Message>asList(new EntitySpawnLightningStrikeMessage(entity.getId(), entity.getPosition().getBlockX(), entity.getPosition().getBlockY(), entity.getPosition().getBlockZ()));
-	}
 }

--- a/src/main/java/org/spout/vanilla/protocol/entity/VanillaPlayerProtocol.java
+++ b/src/main/java/org/spout/vanilla/protocol/entity/VanillaPlayerProtocol.java
@@ -27,134 +27,51 @@
 package org.spout.vanilla.protocol.entity;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import net.royawesome.jlibnoise.MathHelper;
 
 import org.spout.api.entity.Controller;
 import org.spout.api.entity.Entity;
-import org.spout.api.geo.discrete.Transform;
 import org.spout.api.inventory.ItemStack;
-import org.spout.api.protocol.EntityProtocol;
 import org.spout.api.protocol.Message;
 import org.spout.api.util.Parameter;
 
 import org.spout.vanilla.entity.VanillaPlayerController;
-import org.spout.vanilla.entity.component.HeadOwner;
-import org.spout.vanilla.protocol.msg.DestroyEntitiesMessage;
-import org.spout.vanilla.protocol.msg.entity.EntityHeadYawMessage;
-import org.spout.vanilla.protocol.msg.entity.EntityRelativePositionMessage;
-import org.spout.vanilla.protocol.msg.entity.EntityRelativePositionRotationMessage;
-import org.spout.vanilla.protocol.msg.entity.EntityRotationMessage;
 import org.spout.vanilla.protocol.msg.entity.EntitySpawnPlayerMessage;
-import org.spout.vanilla.protocol.msg.entity.EntityTeleportMessage;
-import org.spout.vanilla.protocol.msg.entity.EntityVelocityMessage;
 
-import static org.spout.vanilla.protocol.ChannelBufferUtils.protocolifyPosition;
-import static org.spout.vanilla.protocol.ChannelBufferUtils.protocolifyRotation;
-
-public class VanillaPlayerProtocol implements EntityProtocol {
+public class VanillaPlayerProtocol extends VanillaEntityProtocol {
 	private static final int MC_FULL_AIR = 300;
 
 	@Override
-	public Message[] getSpawnMessage(Entity entity) {
+	public List<Message> getSpawnMessages(Entity entity) {
 		Controller c = entity.getController();
-		if (c == null) {
-			return null;
+		if (!(c instanceof VanillaPlayerController)) {
+			return Collections.emptyList();
 		}
 
-		if (c instanceof VanillaPlayerController) {
-			int id = entity.getId();
-			int x = (int) (entity.getPosition().getX() * 32);
-			int y = (int) (entity.getPosition().getY() * 32);
-			int z = (int) (entity.getPosition().getZ() * 32);
-			int r = (int) (-entity.getYaw() * 32); //cardinal directions differ
-			int p = (int) (entity.getPitch() * 32);
+		int id = entity.getId();
+		int x = (int) (entity.getPosition().getX() * 32);
+		int y = (int) (entity.getPosition().getY() * 32);
+		int z = (int) (entity.getPosition().getZ() * 32);
+		int r = (int) (-entity.getYaw() * 32); //cardinal directions differ
+		int p = (int) (entity.getPitch() * 32);
 
-			VanillaPlayerController playerController = (VanillaPlayerController) c;
-			int item = 0;
-			ItemStack hand = playerController.getRenderedItemInHand();
-			if (hand != null) {
-				item = hand.getMaterial().getId();
-			}
-
-			int percentAirLeft = 100;// - (playerController.getSuffocation().getAirTicks() * 100 / playerController.getSuffocation().getMaxAirTicks());
-			int airLeft = MathHelper.clamp(percentAirLeft * MC_FULL_AIR, 0, MC_FULL_AIR);
-
-			List<Parameter<?>> parameters = new ArrayList<Parameter<?>>();
-			parameters.add(new Parameter<Short>(Parameter.TYPE_SHORT, 1, (short) airLeft));
-
-			return new Message[]{new EntitySpawnPlayerMessage(id, playerController.getTitle(), x, y, z, r, p, item, parameters)};
+		VanillaPlayerController playerController = (VanillaPlayerController) c;
+		int item = 0;
+		ItemStack hand = playerController.getRenderedItemInHand();
+		if (hand != null) {
+			item = hand.getMaterial().getId();
 		}
 
-		return null;
-	}
+		int percentAirLeft = 100;// - (playerController.getSuffocation().getAirTicks() * 100 / playerController.getSuffocation().getMaxAirTicks());
+		int airLeft = MathHelper.clamp(percentAirLeft * MC_FULL_AIR, 0, MC_FULL_AIR);
 
-	@Override
-	public Message[] getDestroyMessage(Entity entity) {
-		return new Message[]{new DestroyEntitiesMessage(new int[]{entity.getId()})};
-	}
+		List<Parameter<?>> parameters = new ArrayList<Parameter<?>>();
+		parameters.add(new Parameter<Short>(Parameter.TYPE_SHORT, 1, (short) airLeft));
 
-	@Override
-	public Message[] getUpdateMessage(Entity entity) {
-		Controller controller = entity.getController();
-		if (!(controller instanceof VanillaPlayerController)) {
-			return new Message[0];
-		}
-		VanillaPlayerController playerController = (VanillaPlayerController) controller;
-
-		// You have to use the last known CLIENT transform
-		// The last tick transform delta is not enough to properly send update messages
-		// For most entities, an update takes more than one tick before an update message is ready
-		// Do NOT use entity.getLastTransform() because it is not a delta since last tick!
-		Transform prevTransform = playerController.getLastClientTransform();
-		Transform newTransform = entity.getTransform();
-
-		int lastX = protocolifyPosition(prevTransform.getPosition().getX());
-		int lastY = protocolifyPosition(prevTransform.getPosition().getY());
-		int lastZ = protocolifyPosition(prevTransform.getPosition().getZ());
-
-		int newX = protocolifyPosition(newTransform.getPosition().getX());
-		int newY = protocolifyPosition(newTransform.getPosition().getY());
-		int newZ = protocolifyPosition(newTransform.getPosition().getZ());
-		int newYaw = protocolifyRotation(newTransform.getRotation().getYaw());
-		int newPitch = protocolifyRotation(newTransform.getRotation().getPitch());
-
-		int deltaX = newX - lastX;
-		int deltaY = newY - lastY;
-		int deltaZ = newZ - lastZ;
-
-		List<Message> messages = new ArrayList<Message>(3);
-
-		if (playerController.needsPositionUpdate() || deltaX > 128 || deltaX < -128 || deltaY > 128 || deltaY < -128 || deltaZ > 128 || deltaZ < -128) {
-			messages.add(new EntityTeleportMessage(entity.getId(), newX, newY, newZ, newYaw, newPitch));
-			playerController.setLastClientTransform(newTransform);
-		} else {
-			boolean moved = !prevTransform.getPosition().equals(newTransform.getPosition());
-			boolean looked = !prevTransform.getRotation().equals(newTransform.getRotation());
-			if (moved) {
-				if (looked) {
-					messages.add(new EntityRelativePositionRotationMessage(entity.getId(), deltaX, deltaY, deltaZ, newYaw, newPitch));
-					playerController.setLastClientTransform(newTransform);
-				} else {
-					messages.add(new EntityRelativePositionMessage(entity.getId(), deltaX, deltaY, deltaZ));
-					playerController.getLastClientTransform().setPosition(newTransform.getPosition());
-				}
-			} else if (looked) {
-				messages.add(new EntityRotationMessage(entity.getId(), newYaw, newPitch));
-				playerController.getLastClientTransform().setRotation(newTransform.getRotation());
-			}
-		}
-		if (playerController.needsVelocityUpdate()) {
-			messages.add(new EntityVelocityMessage(entity.getId(), playerController.getVelocity()));
-		}
-		if (controller instanceof HeadOwner) {
-			HeadOwner headOwner = (HeadOwner) controller;
-			if (headOwner.getHead().yawChanged()) {
-				messages.add(new EntityHeadYawMessage(entity.getId(), protocolifyRotation(headOwner.getHead().getYaw())));
-			}
-		}
-
-		return messages.toArray(new Message[messages.size()]);
+		return Arrays.<Message>asList(new EntitySpawnPlayerMessage(id, playerController.getTitle(), x, y, z, r, p, item, parameters));
 	}
 }

--- a/src/main/java/org/spout/vanilla/protocol/entity/living/HumanEntityProtocol.java
+++ b/src/main/java/org/spout/vanilla/protocol/entity/living/HumanEntityProtocol.java
@@ -27,6 +27,8 @@
 package org.spout.vanilla.protocol.entity.living;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import org.spout.api.entity.Controller;
@@ -41,11 +43,13 @@ import org.spout.vanilla.protocol.msg.entity.EntitySpawnPlayerMessage;
 
 public class HumanEntityProtocol extends VanillaEntityProtocol {
 	@Override
-	public Message[] getSpawnMessage(Entity entity) {
+	public List<Message> getSpawnMessages(Entity entity) {
 		Controller c = entity.getController();
-		if (c == null) {
-			return null;
+		if (c == null || !(c instanceof Human)) {
+			return Collections.emptyList();
 		}
+		Human npc = (Human) c;
+
 		int id = entity.getId();
 		int x = (int) (entity.getPosition().getX() * 32);
 		int y = (int) (entity.getPosition().getY() * 32);
@@ -53,17 +57,13 @@ public class HumanEntityProtocol extends VanillaEntityProtocol {
 		int r = (int) (-entity.getYaw() * 32);
 		int p = (int) (entity.getPitch() * 32);
 
-		if (c instanceof Human) {
-			Human npc = (Human) c;
-			int item = 0;
-			ItemStack hand = npc.getRenderedItemInHand();
-			if (hand != null) {
-				item = hand.getMaterial().getId();
-			}
-			List<Parameter<?>> parameters = new ArrayList<Parameter<?>>();
-			parameters.add(new Parameter<Short>(Parameter.TYPE_SHORT, 1, (short) 100));
-			return new Message[]{new EntitySpawnPlayerMessage(id, npc.getDisplayName(), x, y, z, r, p, item, parameters)};
+		int item = 0;
+		ItemStack hand = npc.getRenderedItemInHand();
+		if (hand != null) {
+			item = hand.getMaterial().getId();
 		}
-		return null;
+		List<Parameter<?>> parameters = new ArrayList<Parameter<?>>();
+		parameters.add(new Parameter<Short>(Parameter.TYPE_SHORT, 1, (short) 100));
+		return Arrays.<Message>asList(new EntitySpawnPlayerMessage(id, npc.getDisplayName(), x, y, z, r, p, item, parameters));
 	}
 }

--- a/src/main/java/org/spout/vanilla/protocol/entity/object/FallingBlockProtocol.java
+++ b/src/main/java/org/spout/vanilla/protocol/entity/object/FallingBlockProtocol.java
@@ -27,6 +27,8 @@
 package org.spout.vanilla.protocol.entity.object;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 import org.spout.api.entity.Controller;
 import org.spout.api.entity.Entity;
@@ -49,23 +51,22 @@ public class FallingBlockProtocol extends BasicVehicleEntityProtocol {
 	}
 
 	@Override
-	public Message[] getSpawnMessage(Entity entity) {
+	public List<Message> getSpawnMessages(Entity entity) {
 		final Controller controller = entity.getController();
-		if (controller instanceof MovingBlock) {
-			int spawnId;
-			BlockMaterial mat = ((MovingBlock) controller).getMaterial();
-			if (mat.equals(VanillaMaterials.DRAGON_EGG)) {
-				spawnId = 74;
-			} else if (mat.equals(VanillaMaterials.GRAVEL)) {
-				spawnId = 71;
-			} else {
-				spawnId = 70; // sand
-			}
-			Point position = entity.getPosition();
-			EntitySpawnVehicleMessage msg = new EntitySpawnVehicleMessage(entity.getId(), spawnId, position);
-			return new Message[]{msg, new EntityMetadataMessage(entity.getId(), Arrays.<Parameter<?>>asList(new Parameter<Short>(Parameter.TYPE_SHORT, BLOCK_TYPE_METADATA_INDEX, VanillaMaterials.getMinecraftId(mat))))};
-		} else {
-			return null;
+		if (!(controller instanceof MovingBlock)) {
+			return Collections.emptyList();
 		}
+		int spawnId;
+		BlockMaterial mat = ((MovingBlock) controller).getMaterial();
+		if (mat.equals(VanillaMaterials.DRAGON_EGG)) {
+			spawnId = 74;
+		} else if (mat.equals(VanillaMaterials.GRAVEL)) {
+			spawnId = 71;
+		} else {
+			spawnId = 70; // sand
+		}
+		Point position = entity.getPosition();
+		List<Parameter<?>> parameters = Arrays.<Parameter<?>>asList(new Parameter<Short>(Parameter.TYPE_SHORT, BLOCK_TYPE_METADATA_INDEX, VanillaMaterials.getMinecraftId(mat)));
+		return Arrays.<Message>asList(new EntitySpawnVehicleMessage(entity.getId(), spawnId, position), new EntityMetadataMessage(entity.getId(), parameters));
 	}
 }

--- a/src/main/java/org/spout/vanilla/protocol/entity/object/ItemEntityProtocol.java
+++ b/src/main/java/org/spout/vanilla/protocol/entity/object/ItemEntityProtocol.java
@@ -26,6 +26,10 @@
  */
 package org.spout.vanilla.protocol.entity.object;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 import org.spout.api.entity.Controller;
 import org.spout.api.entity.Entity;
 import org.spout.api.protocol.Message;
@@ -37,28 +41,24 @@ import org.spout.vanilla.protocol.msg.entity.EntitySpawnItemMessage;
 
 public class ItemEntityProtocol extends VanillaEntityProtocol {
 	@Override
-	public Message[] getSpawnMessage(Entity entity) {
-		if (entity == null || entity.getController() == null) {
-			return null;
-		}
+	public List<Message> getSpawnMessages(Entity entity) {
 		final Controller c = entity.getController();
+		if (!(c instanceof Item)) {
+			return Collections.emptyList();
+		}
+		Item pi = (Item) c;
 		int id = entity.getId();
 		int x = (int) (entity.getPosition().getX() * 32);
 		int y = (int) (entity.getPosition().getY() * 32);
 		int z = (int) (entity.getPosition().getZ() * 32);
 		int r = (int) (entity.getYaw() * 32);
 		int p = (int) (entity.getPitch() * 32);
-		if (c instanceof Item) {
-			Item pi = (Item) c;
-			if (pi.getMaterial() == null) {
-				return null;
-			}
+		if (pi.getMaterial() == null) {
 			int typeId = VanillaMaterials.getMinecraftId(pi.getMaterial());
 			if (typeId > 0) {
-				return new Message[]{new EntitySpawnItemMessage(id, typeId, pi.getAmount(), pi.getData(), x, y, z, r, p, (int) pi.getParent().getRoll())};
+				return Arrays.<Message>asList(new EntitySpawnItemMessage(id, typeId, pi.getAmount(), pi.getData(), x, y, z, r, p, (int) pi.getParent().getRoll()));
 			}
 		}
-
-		return null;
+		return Collections.emptyList();
 	}
 }

--- a/src/main/java/org/spout/vanilla/protocol/entity/object/PaintingEntityProtocol.java
+++ b/src/main/java/org/spout/vanilla/protocol/entity/object/PaintingEntityProtocol.java
@@ -26,6 +26,10 @@
  */
 package org.spout.vanilla.protocol.entity.object;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 import org.spout.api.entity.Entity;
 import org.spout.api.protocol.Message;
 
@@ -35,16 +39,11 @@ import org.spout.vanilla.protocol.msg.entity.EntitySpawnPaintingMessage;
 
 public class PaintingEntityProtocol extends VanillaEntityProtocol {
 	@Override
-	public Message[] getSpawnMessage(Entity entity) {
-		if (entity.getController() == null) {
-			return null;
-		}
+	public List<Message> getSpawnMessages(Entity entity) {
 		if (!(entity.getController() instanceof Painting)) {
-			return null;
+			return Collections.emptyList();
 		}
 		Painting painting = (Painting) entity.getController();
-		Message[] toRet = new Message[1];
-		toRet[0] = new EntitySpawnPaintingMessage(entity.getId(), painting.getPaintingStyle().name(), entity.getPosition(), painting.getFace());
-		return toRet;
+		return Arrays.<Message>asList(new EntitySpawnPaintingMessage(entity.getId(), painting.getPaintingStyle().name(), entity.getPosition(), painting.getFace()));
 	}
 }

--- a/src/main/java/org/spout/vanilla/protocol/entity/object/XPOrbEntityProtocol.java
+++ b/src/main/java/org/spout/vanilla/protocol/entity/object/XPOrbEntityProtocol.java
@@ -26,6 +26,10 @@
  */
 package org.spout.vanilla.protocol.entity.object;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 import org.spout.api.entity.Controller;
 import org.spout.api.entity.Entity;
 import org.spout.api.protocol.Message;
@@ -36,15 +40,15 @@ import org.spout.vanilla.protocol.msg.entity.EntitySpawnExperienceOrbMessage;
 
 public class XPOrbEntityProtocol extends VanillaEntityProtocol {
 	@Override
-	public Message[] getSpawnMessage(Entity entity) {
+	public List<Message> getSpawnMessages(Entity entity) {
 		final Controller c = entity.getController();
-		if (c == null || !(c instanceof XPOrb)) {
-			return null;
+		if (!(c instanceof XPOrb)) {
+			return Collections.emptyList();
 		}
 		int id = entity.getId();
 		int x = (int) (entity.getPosition().getX() * 32);
 		int y = (int) (entity.getPosition().getY() * 32);
 		int z = (int) (entity.getPosition().getZ() * 32);
-		return new Message[]{new EntitySpawnExperienceOrbMessage(id, x, y, z, ((XPOrb) c).getExperience())};
+		return Arrays.<Message>asList(new EntitySpawnExperienceOrbMessage(id, x, y, z, ((XPOrb) c).getExperience()));
 	}
 }

--- a/src/main/java/org/spout/vanilla/protocol/handler/ClientStatusHandler.java
+++ b/src/main/java/org/spout/vanilla/protocol/handler/ClientStatusHandler.java
@@ -26,6 +26,8 @@
  */
 package org.spout.vanilla.protocol.handler;
 
+import java.util.List;
+
 import org.spout.api.Spout;
 import org.spout.api.entity.Player;
 import org.spout.api.event.Event;
@@ -42,7 +44,6 @@ import org.spout.vanilla.entity.source.HealthChangeReason;
 import org.spout.vanilla.event.player.PlayerRespawnEvent;
 import org.spout.vanilla.protocol.VanillaProtocol;
 import org.spout.vanilla.protocol.msg.ClientStatusMessage;
-import org.spout.vanilla.util.VanillaNetworkUtil;
 
 public class ClientStatusHandler extends MessageHandler<ClientStatusMessage> {
 	@Override
@@ -73,8 +74,15 @@ public class ClientStatusHandler extends MessageHandler<ClientStatusMessage> {
 			//send spawn to everyone else
 			EntityProtocol ep = controller.getType().getEntityProtocol(VanillaPlugin.VANILLA_PROTOCOL_ID);
 			if (ep != null) {
-				Message[] spawn = ep.getSpawnMessage(player);
-				VanillaNetworkUtil.broadcastPacket(new Player[]{player}, spawn);
+				List<Message> messages = ep.getSpawnMessages(player);
+				for (Player otherPlayer : player.getWorld().getPlayers()) {
+					if (player == otherPlayer) {
+						continue;
+					}
+					for (Message smessage : messages) {
+						otherPlayer.getSession().send(false, smessage);
+					}
+				}
 			}
 		}
 	}

--- a/src/main/java/org/spout/vanilla/protocol/handler/KeepAliveMessageHandler.java
+++ b/src/main/java/org/spout/vanilla/protocol/handler/KeepAliveMessageHandler.java
@@ -40,6 +40,6 @@ public class KeepAliveMessageHandler extends MessageHandler<KeepAliveMessage> {
 		}
 
 		VanillaPlayerController mp = (VanillaPlayerController) session.getPlayer().getController();
-		mp.getPingComponent().resetTimeout(message.getPingId());
+		mp.getNetworkComponent().resetTimeout(message.getPingId());
 	}
 }


### PR DESCRIPTION
Signed-off-by: Irmo van den Berge bergerkiller@gmail.com

Added new network components to sync player information. These will be further improved so that the Stats update event gets removed and the message is sent in the getUpdateMessages of the Player Protocol.

The protocols have been updates to work with the new API. The player and entity update message logic has been merged together using a shared interface. (update position network component)

All pulls:
https://github.com/VanillaDev/Vanilla/pull/299
https://github.com/SpoutDev/SpoutAPI/pull/340
https://github.com/SpoutDev/Spout/pull/1974
