### PR TITLE
Added customizable outdated client / server messages

### DIFF
--- a/src/main/java/org/spout/vanilla/configuration/VanillaConfiguration.java
+++ b/src/main/java/org/spout/vanilla/configuration/VanillaConfiguration.java
@@ -47,6 +47,8 @@ public class VanillaConfiguration extends ConfigurationHolderConfiguration {
 	public static final ConfigurationHolder SPAWN_PROTECTION_RADIUS = new ConfigurationHolder(10, "general", "spawn-protection-radius");
 	public static final ConfigurationHolder CHUNK_INIT = new ConfigurationHolder("client", "general", "chunk-init");
 	public static final ConfigurationHolder HARDCORE_MODE = new ConfigurationHolder(false, "general", "hardcore-mode");
+	public static final ConfigurationHolder OUTDATED_SERVER_MESSAGE = new ConfigurationHolder("Outdated server!","general","outdated-server");
+	public static final ConfigurationHolder OUTDATED_CLIENT_MESSAGE = new ConfigurationHolder("Outdated client!","general","outdated-client");
 	// Physics
 	public static final ConfigurationHolder GRAVEL_PHYSICS = new ConfigurationHolder(true, "physics", "gravel");
 	public static final ConfigurationHolder FIRE_PHYSICS = new ConfigurationHolder(true, "physics", "fire");
@@ -81,6 +83,7 @@ public class VanillaConfiguration extends ConfigurationHolderConfiguration {
 	public static final ConfigurationHolder ENCRYPT_KEY_PADDING = new ConfigurationHolder("PKCS1", "encrypt", "key-padding");
 	public static final ConfigurationHolder ENCRYPT_STREAM_ALGORITHM = new ConfigurationHolder("AES", "encrypt", "stream-algorithm");
 	public static final ConfigurationHolder ENCRYPT_STREAM_WRAPPER = new ConfigurationHolder("CFB8", "encrypt", "stream-wrapper");
+
 
 	public VanillaConfiguration(File dataFolder) {
 		super(new YamlConfiguration(new File(dataFolder, "config.yml")));

--- a/src/main/java/org/spout/vanilla/protocol/handler/bootstrap/BootstrapHandshakeMessageHandler.java
+++ b/src/main/java/org/spout/vanilla/protocol/handler/bootstrap/BootstrapHandshakeMessageHandler.java
@@ -49,10 +49,10 @@ public class BootstrapHandshakeMessageHandler extends MessageHandler<HandshakeMe
 	@Override
 	public void handleServer(Session session, HandshakeMessage message) {
 		if (message.getProtocolVersion() < VanillaPlugin.MINECRAFT_PROTOCOL_ID) {
-			session.disconnect("Outdated client!");
+			session.disconnect(VanillaConfiguration.OUTDATED_CLIENT_MESSAGE.getString());
 			return;
 		} else if (message.getProtocolVersion() > VanillaPlugin.MINECRAFT_PROTOCOL_ID) {
-			session.disconnect("Outdated server!");
+			session.disconnect(VanillaConfiguration.OUTDATED_SERVER_MESSAGE.getString());
 			return;
 		}
 		Session.State state = session.getState();

--- a/src/main/java/org/spout/vanilla/protocol/handler/bootstrap/BootstrapLoginRequestMessageHandler.java
+++ b/src/main/java/org/spout/vanilla/protocol/handler/bootstrap/BootstrapLoginRequestMessageHandler.java
@@ -37,9 +37,9 @@ public class BootstrapLoginRequestMessageHandler extends MessageHandler<LoginReq
 		//		long start = System.currentTimeMillis();
 		//		Spout.getLogger().info("Handshake response took " + (System.currentTimeMillis() - session.getDataMap().get(VanillaProtocol.LOGIN_TIME)) + " ms");
 		//		if (message > VanillaPlugin.MINECRAFT_PROTOCOL_ID) {
-		//			session.disconnect(false, new Object[]{"Outdated server!"});
+		//			session.disconnect(false, new Object[]{VanillaConfiguration.OUTDATED_SERVER_MESSAGE.getString()});
 		//		} else if (message.getId() < VanillaPlugin.MINECRAFT_PROTOCOL_ID) {
-		//			session.disconnect(false, new Object[]{"Outdated client!"});
+		//			session.disconnect(false, new Object[]{VanillaConfiguration.OUTDATED_CLIENT_MESSAGE.getString()});
 		//		} else {
 		//			String handshakeUsername = session.getDataMap().get(VanillaProtocol.HANDSHAKE_USERNAME);
 		//			handshakeUsername = handshakeUsername.split(";")[0];


### PR DESCRIPTION
This is a often requested feature for MessageChanger, which isn't possible, but we can do it directly in Vanilla.

What would be cool that to a later point in time the Spoutclient allows clickable links.

Signed-off-by: dredhorse dredhorse@breiden.net
