### PR TITLE
Update TileEntityData 0x84 packet codec and message classes...

### DIFF
--- a/src/main/java/org/spout/vanilla/protocol/codec/TileEntityDataCodec.java
+++ b/src/main/java/org/spout/vanilla/protocol/codec/TileEntityDataCodec.java
@@ -33,6 +33,9 @@ import org.jboss.netty.buffer.ChannelBuffers;
 
 import org.spout.api.protocol.MessageCodec;
 
+import org.spout.nbt.CompoundMap;
+
+import org.spout.vanilla.protocol.ChannelBufferUtils;
 import org.spout.vanilla.protocol.msg.TileEntityDataMessage;
 
 public class TileEntityDataCodec extends MessageCodec<TileEntityDataMessage> {
@@ -46,22 +49,18 @@ public class TileEntityDataCodec extends MessageCodec<TileEntityDataMessage> {
 		int y = buffer.readShort();
 		int z = buffer.readInt();
 		int action = buffer.readByte();
-		int custom1 = buffer.readInt();
-		int custom2 = buffer.readInt();
-		int custom3 = buffer.readInt();
-		return new TileEntityDataMessage(x, y, z, action, custom1, custom2, custom3);
+		CompoundMap data = ChannelBufferUtils.readCompound(buffer);
+		return new TileEntityDataMessage(x, y, z, action, data);
 	}
 
 	@Override
 	public ChannelBuffer encode(TileEntityDataMessage message) throws IOException {
-		ChannelBuffer buffer = ChannelBuffers.buffer(24);
+		ChannelBuffer buffer = ChannelBuffers.dynamicBuffer();
 		buffer.writeInt(message.getX());
 		buffer.writeShort(message.getY());
 		buffer.writeInt(message.getZ());
 		buffer.writeByte(message.getAction());
-		buffer.writeInt(message.getCustom1());
-		buffer.writeInt(message.getCustom2());
-		buffer.writeInt(message.getCustom3());
+		ChannelBufferUtils.writeCompound(buffer, message.getData());
 		return buffer;
 	}
 }

--- a/src/main/java/org/spout/vanilla/protocol/msg/TileEntityDataMessage.java
+++ b/src/main/java/org/spout/vanilla/protocol/msg/TileEntityDataMessage.java
@@ -30,9 +30,18 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import org.spout.api.protocol.Message;
 import org.spout.api.util.SpoutToStringStyle;
+import org.spout.nbt.CompoundMap;
 
 public class TileEntityDataMessage implements Message {
-	private final int x, y, z, action, custom1, custom2, custom3;
+	private final int x;
+	private final int y;
+	private final int z;
+	private final int action;
+	private int custom1;
+	private int custom2;
+	private int custom3;
+	private CompoundMap data;
+	
 
 	public TileEntityDataMessage(int x, int y, int z, int action, int[] data) {
 		this(x, y, z, action, data.length >= 1 ? data[0] : -1, data.length >= 2 ? data[1] : -1, data.length >= 3 ? data[2] : -1);
@@ -46,6 +55,14 @@ public class TileEntityDataMessage implements Message {
 		this.custom1 = custom1;
 		this.custom2 = custom2;
 		this.custom3 = custom3;
+	}
+
+	public TileEntityDataMessage(int x, int y, int z, int action, CompoundMap data) {
+		this.x = x;
+		this.y = y;
+		this.z = z;
+		this.action = action;
+		this.data = data;
 	}
 
 	public int getX() {
@@ -74,6 +91,10 @@ public class TileEntityDataMessage implements Message {
 
 	public int getCustom3() {
 		return custom3;
+	}
+
+	public CompoundMap getData() {
+		return data;
 	}
 
 	@Override


### PR DESCRIPTION
...to use NBT data instead of 3 custom int values consistent with 1.3 protocol; this change does not alter code beyond the codec and message classes to use the NBT data.

Signed-off-by: AegonTheMad aegonthemad@gmail.com
