### PR TITLE
Generate random enchantment level and add random enchantments

### DIFF
--- a/src/main/java/org/spout/vanilla/entity/VanillaPlayerController.java
+++ b/src/main/java/org/spout/vanilla/entity/VanillaPlayerController.java
@@ -150,7 +150,7 @@ public class VanillaPlayerController extends PlayerController implements Vanilla
 		super.onTick(dt);
 
 		Player player = getParent();
-		if (player == null || player.getSession() == null) {
+		if (player == null || !player.isOnline()) {
 			return;
 		}
 	}

--- a/src/main/java/org/spout/vanilla/entity/block/Dispenser.java
+++ b/src/main/java/org/spout/vanilla/entity/block/Dispenser.java
@@ -55,7 +55,8 @@ public class Dispenser extends VanillaWindowBlockController implements Inventory
 		if (getDataMap().containsKey(VanillaData.ITEMS)) {
 			this.inventory.setContents(getDataMap().get(VanillaData.ITEMS));
 		}
-		this.isPowered = VanillaMaterials.DISPENSER.isReceivingPower(this.getBlock());
+		//TODO: any chunk method call can not be used in onAttached - causes stack overflow when loading controllers from saves
+		//this.isPowered = VanillaMaterials.DISPENSER.isReceivingPower(this.getBlock());
 	}
 
 	@Override

--- a/src/main/java/org/spout/vanilla/entity/block/Furnace.java
+++ b/src/main/java/org/spout/vanilla/entity/block/Furnace.java
@@ -61,7 +61,8 @@ public class Furnace extends VanillaWindowBlockController implements InventoryOw
 		if (getDataMap().containsKey(VanillaData.ITEMS)) {
 			this.inventory.setContents(getDataMap().get(VanillaData.ITEMS));
 		}
-		this.isBurningState = getBlock().getMaterial() == VanillaMaterials.FURNACE_BURNING;
+		//TODO: any chunk method call can not be used in onAttached - causes stack overflow when loading controllers from saves
+		//this.isBurningState = getBlock().getMaterial() == VanillaMaterials.FURNACE_BURNING;
 	}
 
 	@Override

--- a/src/main/java/org/spout/vanilla/entity/creature/neutral/Human.java
+++ b/src/main/java/org/spout/vanilla/entity/creature/neutral/Human.java
@@ -42,7 +42,7 @@ public class Human extends Creature {
 
 	@Override
 	public void onAttached() {
-		if (displayName.isEmpty()) {
+		if (displayName == null || displayName.isEmpty()) {
 			displayName = getDataMap().get(Data.TITLE);
 		}
 		if (renderedItemInHand == null) {

--- a/src/main/java/org/spout/vanilla/entity/object/misc/Painting.java
+++ b/src/main/java/org/spout/vanilla/entity/object/misc/Painting.java
@@ -39,7 +39,7 @@ public class Painting extends Substance {
 
 	@Override
 	public boolean isSavable() {
-		return true;
+		return false;
 	}
 
 	public PaintingStyle getPaintingStyle() {

--- a/src/main/java/org/spout/vanilla/material/enchantment/ArmorEnchantment.java
+++ b/src/main/java/org/spout/vanilla/material/enchantment/ArmorEnchantment.java
@@ -30,8 +30,8 @@ import org.spout.vanilla.material.VanillaMaterial;
 import org.spout.vanilla.material.item.armor.Armor;
 
 public abstract class ArmorEnchantment extends Enchantment {
-	protected ArmorEnchantment(String name, int id) {
-		super(name, id);
+	protected ArmorEnchantment(String name, int id, int baseEnchantmentLevel, int deltaEnchantmentLevel, int enchantmentLevelRange) {
+		super(name, id, baseEnchantmentLevel, deltaEnchantmentLevel, enchantmentLevelRange);
 	}
 
 	@Override
@@ -40,7 +40,7 @@ public abstract class ArmorEnchantment extends Enchantment {
 	}
 
 	@Override
-	public int getMaximumLevel() {
+	public int getMaximumPowerLevel() {
 		return 4;
 	}
 

--- a/src/main/java/org/spout/vanilla/material/enchantment/BowEnchantment.java
+++ b/src/main/java/org/spout/vanilla/material/enchantment/BowEnchantment.java
@@ -30,8 +30,8 @@ import org.spout.vanilla.material.VanillaMaterial;
 import org.spout.vanilla.material.item.tool.weapon.Bow;
 
 public abstract class BowEnchantment extends Enchantment {
-	protected BowEnchantment(String name, int id) {
-		super(name, id);
+	protected BowEnchantment(String name, int id, int baseEnchantmentLevel, int deltaEnchantmentLevel, int enchantmentLevelRange) {
+		super(name, id, baseEnchantmentLevel, deltaEnchantmentLevel, enchantmentLevelRange);
 	}
 
 	@Override
@@ -40,7 +40,7 @@ public abstract class BowEnchantment extends Enchantment {
 	}
 
 	@Override
-	public int getMaximumLevel() {
+	public int getMaximumPowerLevel() {
 		return 1;
 	}
 

--- a/src/main/java/org/spout/vanilla/material/enchantment/Enchantment.java
+++ b/src/main/java/org/spout/vanilla/material/enchantment/Enchantment.java
@@ -34,10 +34,17 @@ import org.spout.vanilla.material.VanillaMaterial;
 public abstract class Enchantment {
 	private final String name;
 	private final int id;
+	/**
+	 * Used to compute {@link getMinimumLevel} and {@link getMaximumLevel}
+	 */
+	protected final int baseEnchantmentLevel, deltaEnchantmentLevel, enchantmentLevelRange;
 
-	protected Enchantment(String name, int id) {
+	protected Enchantment(String name, int id, int baseEnchantmentLevel, int deltaEnchantmentLevel, int enchantmentLevelRange) {
 		this.name = name;
 		this.id = id;
+		this.baseEnchantmentLevel = baseEnchantmentLevel;
+		this.deltaEnchantmentLevel = deltaEnchantmentLevel;
+		this.enchantmentLevelRange = enchantmentLevelRange;
 	}
 
 	/**
@@ -47,10 +54,28 @@ public abstract class Enchantment {
 	public abstract boolean canEnchant(VanillaMaterial material);
 
 	/**
-	 * Gets the maximum level this enchantment can be
-	 * @return maximum level
+	 * Gets the maximum power level this enchantment can be
+	 * @return maximum power level
 	 */
-	public abstract int getMaximumLevel();
+	public abstract int getMaximumPowerLevel();
+
+	/**
+	 * Gets the minimum modified enchantment level allowed to produce this enchantment with a given power level
+	 * @param powerLevel The desired power level of the enchantment
+	 * @return Minimum level
+	 */
+	public int getMinimumLevel(int powerLevel) {
+		return baseEnchantmentLevel + (powerLevel - 1) * deltaEnchantmentLevel;
+	}
+
+	/**
+	 * Gets the maximum modified enchantment level allowed to produce this enchantment with a given power level
+	 * @param powerLevel The desired power level of the enchantment
+	 * @return Maximum level
+	 */
+	public int getMaximumLevel(int powerLevel) {
+		return getMinimumLevel(powerLevel) + enchantmentLevelRange;
+	}
 
 	/**
 	 * Gets the weight of this enchantment, enchantments with higher weights have a greater chance of being selected during the enchantment process

--- a/src/main/java/org/spout/vanilla/material/enchantment/Enchantments.java
+++ b/src/main/java/org/spout/vanilla/material/enchantment/Enchantments.java
@@ -119,10 +119,7 @@ public class Enchantments {
 	 */
 	public static Enchantment[] values() {
 		Enchantment[] values = new Enchantment[idLookup.size()];
-		for (int i = 0; i < idLookup.size(); i++) {
-			values[i] = idLookup.get(i);
-		}
-
+		idLookup.values().toArray(values);
 		return values;
 	}
 }

--- a/src/main/java/org/spout/vanilla/material/enchantment/SwordEnchantment.java
+++ b/src/main/java/org/spout/vanilla/material/enchantment/SwordEnchantment.java
@@ -30,8 +30,8 @@ import org.spout.vanilla.material.VanillaMaterial;
 import org.spout.vanilla.material.item.tool.weapon.Sword;
 
 public abstract class SwordEnchantment extends Enchantment {
-	protected SwordEnchantment(String name, int id) {
-		super(name, id);
+	protected SwordEnchantment(String name, int id, int baseEnchantmentLevel, int deltaEnchantmentLevel, int enchantmentLevelRange) {
+		super(name, id, baseEnchantmentLevel, deltaEnchantmentLevel, enchantmentLevelRange);
 	}
 
 	@Override
@@ -40,7 +40,7 @@ public abstract class SwordEnchantment extends Enchantment {
 	}
 
 	@Override
-	public int getMaximumLevel() {
+	public int getMaximumPowerLevel() {
 		return 5;
 	}
 

--- a/src/main/java/org/spout/vanilla/material/enchantment/ToolEnchantment.java
+++ b/src/main/java/org/spout/vanilla/material/enchantment/ToolEnchantment.java
@@ -27,20 +27,20 @@
 package org.spout.vanilla.material.enchantment;
 
 import org.spout.vanilla.material.VanillaMaterial;
-import org.spout.vanilla.material.item.tool.Tool;
+import org.spout.vanilla.material.item.tool.MiningTool;
 
 public abstract class ToolEnchantment extends Enchantment {
-	protected ToolEnchantment(String name, int id) {
-		super(name, id);
+	protected ToolEnchantment(String name, int id, int baseEnchantmentLevel, int deltaEnchantmentLevel, int enchantmentLevelRange) {
+		super(name, id, baseEnchantmentLevel, deltaEnchantmentLevel, enchantmentLevelRange);
 	}
 
 	@Override
 	public boolean canEnchant(VanillaMaterial material) {
-		return material instanceof Tool;
+		return material instanceof MiningTool;
 	}
 
 	@Override
-	public int getMaximumLevel() {
+	public int getMaximumPowerLevel() {
 		return 3;
 	}
 }

--- a/src/main/java/org/spout/vanilla/material/enchantment/armor/AquaAffinity.java
+++ b/src/main/java/org/spout/vanilla/material/enchantment/armor/AquaAffinity.java
@@ -32,7 +32,7 @@ import org.spout.vanilla.material.item.armor.Helmet;
 
 public class AquaAffinity extends ArmorEnchantment {
 	public AquaAffinity(String name, int id) {
-		super(name, id);
+		super(name, id, 1, 0, 40);
 	}
 
 	@Override
@@ -41,7 +41,7 @@ public class AquaAffinity extends ArmorEnchantment {
 	}
 
 	@Override
-	public int getMaximumLevel() {
+	public int getMaximumPowerLevel() {
 		return 1;
 	}
 

--- a/src/main/java/org/spout/vanilla/material/enchantment/armor/BlastProtection.java
+++ b/src/main/java/org/spout/vanilla/material/enchantment/armor/BlastProtection.java
@@ -34,7 +34,7 @@ import org.spout.vanilla.material.item.armor.Boots;
 
 public class BlastProtection extends ArmorEnchantment {
 	public BlastProtection(String name, int id) {
-		super(name, id);
+		super(name, id, 5, 8, 12);
 	}
 
 	@Override

--- a/src/main/java/org/spout/vanilla/material/enchantment/armor/FeatherFalling.java
+++ b/src/main/java/org/spout/vanilla/material/enchantment/armor/FeatherFalling.java
@@ -32,7 +32,7 @@ import org.spout.vanilla.material.item.armor.Boots;
 
 public class FeatherFalling extends ArmorEnchantment {
 	public FeatherFalling(String name, int id) {
-		super(name, id);
+		super(name, id, 5, 6, 10);
 	}
 
 	@Override

--- a/src/main/java/org/spout/vanilla/material/enchantment/armor/FireProtection.java
+++ b/src/main/java/org/spout/vanilla/material/enchantment/armor/FireProtection.java
@@ -34,7 +34,7 @@ import org.spout.vanilla.material.item.armor.Boots;
 
 public class FireProtection extends ArmorEnchantment {
 	public FireProtection(String name, int id) {
-		super(name, id);
+		super(name, id, 10, 8, 12);
 	}
 
 	@Override

--- a/src/main/java/org/spout/vanilla/material/enchantment/armor/ProjectileProtection.java
+++ b/src/main/java/org/spout/vanilla/material/enchantment/armor/ProjectileProtection.java
@@ -34,7 +34,7 @@ import org.spout.vanilla.material.item.armor.Boots;
 
 public class ProjectileProtection extends ArmorEnchantment {
 	public ProjectileProtection(String name, int id) {
-		super(name, id);
+		super(name, id, 3, 6, 15);
 	}
 
 	@Override

--- a/src/main/java/org/spout/vanilla/material/enchantment/armor/Protection.java
+++ b/src/main/java/org/spout/vanilla/material/enchantment/armor/Protection.java
@@ -35,7 +35,7 @@ import org.spout.vanilla.material.item.armor.Helmet;
 
 public class Protection extends ArmorEnchantment {
 	public Protection(String name, int id) {
-		super(name, id);
+		super(name, id, 1, 11, 20);
 	}
 
 	@Override

--- a/src/main/java/org/spout/vanilla/material/enchantment/armor/Respiration.java
+++ b/src/main/java/org/spout/vanilla/material/enchantment/armor/Respiration.java
@@ -32,7 +32,7 @@ import org.spout.vanilla.material.item.armor.Helmet;
 
 public class Respiration extends ArmorEnchantment {
 	public Respiration(String name, int id) {
-		super(name, id);
+		super(name, id, 10, 10, 30);
 	}
 
 	@Override
@@ -41,7 +41,7 @@ public class Respiration extends ArmorEnchantment {
 	}
 
 	@Override
-	public int getMaximumLevel() {
+	public int getMaximumPowerLevel() {
 		return 3;
 	}
 

--- a/src/main/java/org/spout/vanilla/material/enchantment/bow/Flame.java
+++ b/src/main/java/org/spout/vanilla/material/enchantment/bow/Flame.java
@@ -30,6 +30,6 @@ import org.spout.vanilla.material.enchantment.BowEnchantment;
 
 public class Flame extends BowEnchantment {
 	public Flame(String name, int id) {
-		super(name, id);
+		super(name, id, 20, 0, 30);
 	}
 }

--- a/src/main/java/org/spout/vanilla/material/enchantment/bow/Infinity.java
+++ b/src/main/java/org/spout/vanilla/material/enchantment/bow/Infinity.java
@@ -30,7 +30,7 @@ import org.spout.vanilla.material.enchantment.BowEnchantment;
 
 public class Infinity extends BowEnchantment {
 	public Infinity(String name, int id) {
-		super(name, id);
+		super(name, id, 20, 0, 30);
 	}
 
 	@Override

--- a/src/main/java/org/spout/vanilla/material/enchantment/bow/Power.java
+++ b/src/main/java/org/spout/vanilla/material/enchantment/bow/Power.java
@@ -30,11 +30,11 @@ import org.spout.vanilla.material.enchantment.BowEnchantment;
 
 public class Power extends BowEnchantment {
 	public Power(String name, int id) {
-		super(name, id);
+		super(name, id, 1, 10, 15);
 	}
 
 	@Override
-	public int getMaximumLevel() {
+	public int getMaximumPowerLevel() {
 		return 5;
 	}
 

--- a/src/main/java/org/spout/vanilla/material/enchantment/bow/Punch.java
+++ b/src/main/java/org/spout/vanilla/material/enchantment/bow/Punch.java
@@ -30,11 +30,11 @@ import org.spout.vanilla.material.enchantment.BowEnchantment;
 
 public class Punch extends BowEnchantment {
 	public Punch(String name, int id) {
-		super(name, id);
+		super(name, id, 12, 20, 25);
 	}
 
 	@Override
-	public int getMaximumLevel() {
+	public int getMaximumPowerLevel() {
 		return 2;
 	}
 }

--- a/src/main/java/org/spout/vanilla/material/enchantment/sword/BaneOfArthropods.java
+++ b/src/main/java/org/spout/vanilla/material/enchantment/sword/BaneOfArthropods.java
@@ -33,7 +33,7 @@ import org.spout.vanilla.material.enchantment.SwordEnchantment;
 
 public class BaneOfArthropods extends SwordEnchantment {
 	public BaneOfArthropods(String name, int id) {
-		super(name, id);
+		super(name, id, 5, 8, 20);
 	}
 
 	@Override

--- a/src/main/java/org/spout/vanilla/material/enchantment/sword/FireAspect.java
+++ b/src/main/java/org/spout/vanilla/material/enchantment/sword/FireAspect.java
@@ -30,11 +30,11 @@ import org.spout.vanilla.material.enchantment.SwordEnchantment;
 
 public class FireAspect extends SwordEnchantment {
 	public FireAspect(String name, int id) {
-		super(name, id);
+		super(name, id, 10, 20, 50);
 	}
 
 	@Override
-	public int getMaximumLevel() {
+	public int getMaximumPowerLevel() {
 		return 2;
 	}
 

--- a/src/main/java/org/spout/vanilla/material/enchantment/sword/Knockback.java
+++ b/src/main/java/org/spout/vanilla/material/enchantment/sword/Knockback.java
@@ -30,11 +30,11 @@ import org.spout.vanilla.material.enchantment.SwordEnchantment;
 
 public class Knockback extends SwordEnchantment {
 	public Knockback(String name, int id) {
-		super(name, id);
+		super(name, id, 5, 20, 50);
 	}
 
 	@Override
-	public int getMaximumLevel() {
+	public int getMaximumPowerLevel() {
 		return 2;
 	}
 }

--- a/src/main/java/org/spout/vanilla/material/enchantment/sword/Looting.java
+++ b/src/main/java/org/spout/vanilla/material/enchantment/sword/Looting.java
@@ -30,11 +30,11 @@ import org.spout.vanilla.material.enchantment.SwordEnchantment;
 
 public class Looting extends SwordEnchantment {
 	public Looting(String name, int id) {
-		super(name, id);
+		super(name, id, 15, 9, 50);
 	}
 
 	@Override
-	public int getMaximumLevel() {
+	public int getMaximumPowerLevel() {
 		return 3;
 	}
 

--- a/src/main/java/org/spout/vanilla/material/enchantment/sword/Sharpness.java
+++ b/src/main/java/org/spout/vanilla/material/enchantment/sword/Sharpness.java
@@ -33,7 +33,7 @@ import org.spout.vanilla.material.enchantment.SwordEnchantment;
 
 public class Sharpness extends SwordEnchantment {
 	public Sharpness(String name, int id) {
-		super(name, id);
+		super(name, id, 1, 11, 20);
 	}
 
 	@Override

--- a/src/main/java/org/spout/vanilla/material/enchantment/sword/Smite.java
+++ b/src/main/java/org/spout/vanilla/material/enchantment/sword/Smite.java
@@ -33,7 +33,7 @@ import org.spout.vanilla.material.enchantment.SwordEnchantment;
 
 public class Smite extends SwordEnchantment {
 	public Smite(String name, int id) {
-		super(name, id);
+		super(name, id, 5, 8, 20);
 	}
 
 	@Override

--- a/src/main/java/org/spout/vanilla/material/enchantment/tool/Efficiency.java
+++ b/src/main/java/org/spout/vanilla/material/enchantment/tool/Efficiency.java
@@ -30,11 +30,11 @@ import org.spout.vanilla.material.enchantment.ToolEnchantment;
 
 public class Efficiency extends ToolEnchantment {
 	public Efficiency(String name, int id) {
-		super(name, id);
+		super(name, id, 1, 10, 50);
 	}
 
 	@Override
-	public int getMaximumLevel() {
+	public int getMaximumPowerLevel() {
 		return 5;
 	}
 

--- a/src/main/java/org/spout/vanilla/material/enchantment/tool/SilkTouch.java
+++ b/src/main/java/org/spout/vanilla/material/enchantment/tool/SilkTouch.java
@@ -33,7 +33,7 @@ import org.spout.vanilla.material.enchantment.ToolEnchantment;
 
 public class SilkTouch extends ToolEnchantment {
 	public SilkTouch(String name, int id) {
-		super(name, id);
+		super(name, id, 15, 0, 50);
 	}
 
 	@Override
@@ -42,7 +42,7 @@ public class SilkTouch extends ToolEnchantment {
 	}
 
 	@Override
-	public int getMaximumLevel() {
+	public int getMaximumPowerLevel() {
 		return 1;
 	}
 

--- a/src/main/java/org/spout/vanilla/material/enchantment/tool/Unbreaking.java
+++ b/src/main/java/org/spout/vanilla/material/enchantment/tool/Unbreaking.java
@@ -30,7 +30,7 @@ import org.spout.vanilla.material.enchantment.ToolEnchantment;
 
 public class Unbreaking extends ToolEnchantment {
 	public Unbreaking(String name, int id) {
-		super(name, id);
+		super(name, id, 5, 8, 50);
 	}
 
 	@Override

--- a/src/main/java/org/spout/vanilla/util/EnchantmentUtil.java
+++ b/src/main/java/org/spout/vanilla/util/EnchantmentUtil.java
@@ -28,8 +28,10 @@ package org.spout.vanilla.util;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 
 import org.spout.api.inventory.ItemStack;
 
@@ -42,6 +44,7 @@ import org.spout.nbt.Tag;
 import org.spout.vanilla.material.VanillaMaterial;
 import org.spout.vanilla.material.enchantment.Enchantment;
 import org.spout.vanilla.material.enchantment.Enchantments;
+import org.spout.vanilla.material.item.Enchantable;
 
 public class EnchantmentUtil {
 	private EnchantmentUtil() {
@@ -72,7 +75,7 @@ public class EnchantmentUtil {
 	 * Adds the given {@link Enchantment} with the given level to the given item
 	 * @param item ItemStack to add the enchantment to
 	 * @param enchantment Enchantment to add to the item
-	 * @param level Level of the enchantment
+	 * @param level Power level of the enchantment
 	 * @param force Whether the enchantment should be forced on the item
 	 * @return Whether the enchantment was able to be added to the item
 	 */
@@ -93,15 +96,18 @@ public class EnchantmentUtil {
 				}
 			}
 
-			List<Tag<?>> enchantments = new ArrayList<Tag<?>>();
-			if (item.getNBTData() != null && item.getNBTData().containsKey("ench")) {
-				enchantments = ((ListTag) item.getNBTData().get("ench")).getValue();
-			}
+			CompoundMap nbtData = item.getNBTData();
+			if (nbtData == null)
+				nbtData = new CompoundMap();
+			List<CompoundTag> enchantments = new ArrayList<CompoundTag>();
+			if (nbtData.get("ench") instanceof ListTag<?>)
+				enchantments = new ArrayList<CompoundTag>(((ListTag<CompoundTag>) nbtData.get("ench")).getValue());
 			CompoundMap map = new CompoundMap();
 			map.put(new ShortTag("id", (short) enchantment.getId()));
 			map.put(new ShortTag("lvl", (short) level));
-			enchantments.add(new CompoundTag("ench", map));
-			item.setNBTData(new CompoundMap(enchantments));
+			enchantments.add(new CompoundTag(null, map));
+			nbtData.put(new ListTag<CompoundTag>("ench", CompoundTag.class, enchantments));
+			item.setNBTData(nbtData);
 		}
 
 		return true;
@@ -111,34 +117,46 @@ public class EnchantmentUtil {
 	 * Returns the level of the given {@link Enchantment}
 	 * @param item Item containing the enchantment
 	 * @param enchantment Enchantment to check
-	 * @return Level of the enchantment, or 0 if the item does not contain the enchantment
+	 * @return Power level of the enchantment, or 0 if the item does not contain the enchantment
 	 */
 	public static int getEnchantmentLevel(ItemStack item, Enchantment enchantment) {
-		return getEnchantments(item).containsKey(enchantment) ? getEnchantments(item).get(enchantment) : 0;
+		if (item.getNBTData() == null)
+			return 0;
+		Tag<?> enchTag = item.getNBTData().get("ench");
+		if (!(enchTag instanceof ListTag<?>))
+			return 0;
+		@SuppressWarnings("unchecked")
+		List<CompoundTag> enchantmentList = ((ListTag<CompoundTag>) enchTag).getValue();
+		for (CompoundTag tag : enchantmentList) {
+			Tag<?> idTag = tag.getValue().get("id");
+			Tag<?> lvlTag = tag.getValue().get("lvl");
+			if (idTag instanceof ShortTag && lvlTag instanceof ShortTag && ((ShortTag) idTag).getValue() == enchantment.getId()) {
+				return (int) ((ShortTag) lvlTag).getValue();
+			}
+		}
+		return 0;
 	}
 
 	/**
 	 * Returns all {@link Enchantment}s attached to the given item
 	 * @param item Item to check
-	 * @return Map of the item's enchantments along with their level
+	 * @return Map of the item's enchantments along with their power level
 	 */
 	public static Map<Enchantment, Integer> getEnchantments(ItemStack item) {
 		Map<Enchantment, Integer> enchantments = new HashMap<Enchantment, Integer>();
-		if (item.getNBTData() == null || !item.getNBTData().containsKey("ench")) {
+		if (item.getNBTData() == null)
 			return enchantments;
-		}
-
-		List<Short> ids = new ArrayList<Short>();
-		List<Short> levels = new ArrayList<Short>();
-		for (Tag tag : ((CompoundMap) item.getNBTData().get("ench").getValue()).values()) {
-			if (tag.getName().equals("id")) {
-				ids.add((Short) tag.getValue());
-			} else if (tag.getName().equals("lvl")) {
-				levels.add((Short) tag.getValue());
+		Tag<?> enchTag = item.getNBTData().get("ench");
+		if (!(enchTag instanceof ListTag<?>))
+			return enchantments;
+		@SuppressWarnings("unchecked")
+		List<CompoundTag> enchantmentList = ((ListTag<CompoundTag>) enchTag).getValue();
+		for (CompoundTag tag : enchantmentList) {
+			Tag<?> idTag = tag.getValue().get("id");
+			Tag<?> lvlTag = tag.getValue().get("lvl");
+			if (idTag instanceof ShortTag && lvlTag instanceof ShortTag) {
+				enchantments.put(Enchantments.getById(((ShortTag) idTag).getValue()), (int) ((ShortTag) lvlTag).getValue());
 			}
-		}
-		for (int i = 0; i < ids.size(); i++) {
-			enchantments.put(Enchantments.getById(ids.get(i)), (int) levels.get(i));
 		}
 		return enchantments;
 	}
@@ -150,15 +168,103 @@ public class EnchantmentUtil {
 	 * @return true if the item contains the enchantment
 	 */
 	public static boolean hasEnchantment(ItemStack item, Enchantment enchantment) {
-		if (item.getNBTData() == null || !item.getNBTData().containsKey("ench")) {
-			return false;
-		}
+		return getEnchantmentLevel(item, enchantment) > 0;
+	}
 
-		for (Tag tag : ((CompoundMap) item.getNBTData().get("ench").getValue()).values()) {
-			if (tag.getName().equals("id") && ((ShortTag) tag).getValue() == enchantment.getId()) {
-				return true;
+	/**
+	 * Generates a random enchantment level for use in the enchantment interface
+	 * @param random The random number generator to be used
+	 * @param slotNumber The slot number (From 0 to 2) of the slot in the enchantment interface
+	 * @param bookshelves The number of bookshelves connected to the enchantment table
+	 * @return The enchantment level
+	 */
+	public static int getRandomEnchantmentLevel(Random random, int slotNumber, int bookshelves) {
+		if (bookshelves > 15)
+			bookshelves = 15;
+		int baseLevel = random.nextInt(8) + 1 + (bookshelves >> 1) + random.nextInt(bookshelves + 1);
+		switch (slotNumber) {
+		case 0:
+			return Math.max(baseLevel / 3, 1);
+		case 1:
+			return baseLevel * 2 / 3 + 1;
+		default:
+			return Math.max(baseLevel, bookshelves * 2);
+		}
+	}
+
+	/**
+	 * An object holding both the type of {@link Enchantment} as well as its power level (I, II, III, IV, V)
+	 */
+	private final static class EnchantmentData {
+		public final Enchantment enchantment;
+		public final int powerLevel;
+
+		EnchantmentData(Enchantment enchantment, int powerLevel) {
+			this.enchantment = enchantment;
+			this.powerLevel = powerLevel;
+		}
+	}
+
+	/**
+	 * Tries to add random enchantments to an item stack
+	 * @param random The random number generator to be used
+	 * @param itemStack The item stack to enchant. No enchantments will be added if the material doesn't implement {@link Enchantable}
+	 * @param level The level of enchantment
+	 * @return Whether enchantments were successfully added
+	 * 
+	 */
+	public static boolean addRandomEnchantments(Random random, ItemStack itemStack, int level) {
+		VanillaMaterial material = (VanillaMaterial) itemStack.getMaterial();
+		if (!(material instanceof Enchantable))
+			return false;
+		int enchantibility = ((Enchantable) material).getEnchantability();
+		// modify level depending on item enchantibility
+		level += 1 + random.nextInt(enchantibility / 4 + 1) + random.nextInt(enchantibility / 4 + 1);
+		// modify level by a random multiplier from 0.85 to 1.15 (triangular
+		// distribution)
+		float multiplier = (random.nextFloat() + random.nextFloat() - 1.0F) * 0.15F + 1.0F;
+		level = Math.max((int) ((float) level * multiplier + 0.5F), 1);
+
+		Map<EnchantmentData, Integer> enchantmentList = makeEnchantmentList(level, material);
+		boolean succeeded = false;
+		while (enchantmentList != null && !enchantmentList.isEmpty()) {
+			EnchantmentData enchantmentData = VanillaMathHelper.chooseWeightedRandom(random, enchantmentList);
+			if (enchantmentData != null) {
+				succeeded |= addEnchantment(itemStack, enchantmentData.enchantment, enchantmentData.powerLevel, false);
+				// remove any enchantments from the list which aren't compatible
+				// with the one we just added
+				for (Iterator<EnchantmentData> i = enchantmentList.keySet().iterator(); i.hasNext();) {
+					Enchantment conflict = i.next().enchantment;
+					if (!conflict.compatibleWith(enchantmentData.enchantment, material))
+						i.remove();
+				}
+			}
+			// Decide whether to add more enchantments
+			if (random.nextInt(50) > level)
+				break;
+			level /= 2;
+		}
+		return succeeded;
+	}
+
+	/**
+	 * Generates a list of allowed {@link EnchantmentData} for the given item, together with their probability weights
+	 * @param level The modified enchantment level
+	 * @param material The material of the {@link ItemStack} to be enchanted
+	 * @return A map from the allowed {@link EnchantmentData} to their probability weights
+	 */
+	private static Map<EnchantmentData, Integer> makeEnchantmentList(int level, VanillaMaterial material) {
+		Map<EnchantmentData, Integer> output = new HashMap<EnchantmentData, Integer>();
+		Enchantment[] enchantmentList = Enchantments.values();
+		for (Enchantment enchantment : enchantmentList) {
+			if (!enchantment.canEnchant(material))
+				continue;
+			for (int powerLevel = 1; powerLevel <= enchantment.getMaximumPowerLevel(); ++powerLevel) {
+				if (level >= enchantment.getMinimumLevel(powerLevel) && level <= enchantment.getMaximumLevel(powerLevel)) {
+					output.put(new EnchantmentData(enchantment, powerLevel), enchantment.getWeight());
+				}
 			}
 		}
-		return false;
+		return output;
 	}
 }

--- a/src/main/java/org/spout/vanilla/util/VanillaMathHelper.java
+++ b/src/main/java/org/spout/vanilla/util/VanillaMathHelper.java
@@ -26,6 +26,7 @@
  */
 package org.spout.vanilla.util;
 
+import java.util.Map;
 import java.util.Random;
 
 import org.spout.api.math.MathHelper;
@@ -53,8 +54,8 @@ public class VanillaMathHelper {
 	}
 
 	/**
-	 * Gets the (real?) celestial angle at a certain time of the day<br> The use
-	 * of this function is unknown...
+	 * Gets the (real?) celestial angle at a certain time of the day<br>
+	 * The use of this function is unknown...
 	 * @param timeMillis time
 	 * @param timeMillisTune fine runing
 	 * @return celestial angle, a value from 0 to 1
@@ -104,5 +105,26 @@ public class VanillaMathHelper {
 
 	public static float getLookAtPitch(Vector3 offset) {
 		return (float) -Math.toDegrees(Math.atan(offset.getY() / MathHelper.length(offset.getX(), offset.getZ())));
+	}
+
+	/**
+	 * Chooses an item randomly from a list, with the probability of each item proportional to its given weight
+	 * @param random The random number generator to be used
+	 * @param weightMap A map from the items that can be chosen to their respective weights
+	 * @return The randomly chosen item, or null if the total weight is not positive.
+	 */
+	public static <T> T chooseWeightedRandom(Random random, Map<T, Integer> weightMap) {
+		int totalWeight = 0;
+		for (Integer i : weightMap.values())
+			totalWeight += i;
+		if (totalWeight <= 0)
+			return null;
+		int j = random.nextInt(totalWeight);
+		for (T t : weightMap.keySet()) {
+			j -= weightMap.get(t);
+			if (j < 0)
+				return t;
+		}
+		return null;
 	}
 }

--- a/src/test/java/org/spout/vanilla/item/EnchantmentTest.java
+++ b/src/test/java/org/spout/vanilla/item/EnchantmentTest.java
@@ -24,25 +24,33 @@
  * License and see <http://www.spout.org/SpoutDevLicenseV1.txt> for the full license,
  * including the MIT license.
  */
-package org.spout.vanilla.material.enchantment.tool;
+package org.spout.vanilla.item;
 
-import org.spout.vanilla.material.VanillaMaterial;
-import org.spout.vanilla.material.enchantment.Enchantment;
+import org.junit.Test;
+
+import org.spout.api.inventory.ItemStack;
+
+import org.spout.vanilla.material.VanillaMaterials;
 import org.spout.vanilla.material.enchantment.Enchantments;
-import org.spout.vanilla.material.enchantment.ToolEnchantment;
+import org.spout.vanilla.material.item.tool.Tool;
+import org.spout.vanilla.util.EnchantmentUtil;
 
-public class Fortune extends ToolEnchantment {
-	public Fortune(String name, int id) {
-		super(name, id, 15, 9, 50);
-	}
+import static org.junit.Assert.assertTrue;
 
-	@Override
-	public boolean compatibleWith(Enchantment enchantment, VanillaMaterial material) {
-		return !enchantment.equals(Enchantments.SILK_TOUCH);
-	}
+public class EnchantmentTest {
+	@Test
+	public void testUnbreaking() {
+		ItemStack itemStack = new ItemStack(VanillaMaterials.DIAMOND_PICKAXE, 1);
+		EnchantmentUtil.addEnchantment(itemStack, Enchantments.UNBREAKING, 3,
+				false);
+		assertTrue(EnchantmentUtil.getEnchantmentLevel(itemStack,
+				Enchantments.UNBREAKING) == 3);
 
-	@Override
-	public int getWeight() {
-		return 2;
+		Tool tool = (Tool) itemStack.getMaterial();
+		int durabilityLost = 0, trials = 100;
+		for (int i = 0; i < trials; ++i)
+			durabilityLost += tool.getDurabilityPenalty(itemStack);
+		System.out.println("Unbreaking III lost " + durabilityLost
+				+ " durability from " + trials + " actions.");
 	}
 }

--- a/src/test/java/org/spout/vanilla/util/EnchantmentUtilTest.java
+++ b/src/test/java/org/spout/vanilla/util/EnchantmentUtilTest.java
@@ -1,0 +1,107 @@
+/*
+ * This file is part of Vanilla.
+ *
+ * Copyright (c) 2011-2012, VanillaDev <http://www.spout.org/>
+ * Vanilla is licensed under the SpoutDev License Version 1.
+ *
+ * Vanilla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In addition, 180 days after any changes are published, you can use the
+ * software, incorporating those changes, under the terms of the MIT license,
+ * as described in the SpoutDev License Version 1.
+ *
+ * Vanilla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License,
+ * the MIT license and the SpoutDev License Version 1 along with this program.
+ * If not, see <http://www.gnu.org/licenses/> for the GNU Lesser General Public
+ * License and see <http://www.spout.org/SpoutDevLicenseV1.txt> for the full license,
+ * including the MIT license.
+ */
+package org.spout.vanilla.util;
+
+import java.util.Map;
+import java.util.Random;
+
+import org.junit.Test;
+import org.spout.api.inventory.ItemStack;
+import org.spout.vanilla.material.VanillaMaterial;
+import org.spout.vanilla.material.VanillaMaterials;
+import org.spout.vanilla.material.enchantment.Enchantment;
+import org.spout.vanilla.material.enchantment.Enchantments;
+import org.spout.vanilla.util.EnchantmentUtil;
+
+import static org.junit.Assert.assertTrue;
+
+public class EnchantmentUtilTest {
+	@Test
+	public void testRandomEnchantmentLevel() {
+		Random random = new Random();
+		int level;
+		// run a few times due to randomness
+		for (int trial = 0; trial < 5; ++trial) {
+			level = EnchantmentUtil.getRandomEnchantmentLevel(random, 0, 0);
+			assertTrue(level >= 1);
+			assertTrue(level <= 2);
+			level = EnchantmentUtil.getRandomEnchantmentLevel(random, 0, 15);
+			assertTrue(level <= 10);
+			assertTrue(level >= 2);
+			level = EnchantmentUtil.getRandomEnchantmentLevel(random, 1, 0);
+			assertTrue(level >= 1);
+			assertTrue(level <= 6);
+			level = EnchantmentUtil.getRandomEnchantmentLevel(random, 1, 15);
+			assertTrue(level >= 6);
+			assertTrue(level <= 21);
+			level = EnchantmentUtil.getRandomEnchantmentLevel(random, 2, 0);
+			assertTrue(level >= 1);
+			assertTrue(level <= 8);
+			level = EnchantmentUtil.getRandomEnchantmentLevel(random, 2, 15);
+			assertTrue(level == 30);
+		}
+	}
+
+	@Test
+	public void testEnchantmentsList() {
+		Enchantment[] list = Enchantments.values();
+		for (Enchantment enchantment : list)
+			assertTrue(enchantment != null);
+	}
+
+	@Test
+	public void testAddEnchantment() {
+		ItemStack itemStack = new ItemStack(VanillaMaterials.DIAMOND_PICKAXE, 1);
+		EnchantmentUtil.addEnchantment(itemStack, Enchantments.EFFICIENCY, 3, false);
+		EnchantmentUtil.addEnchantment(itemStack, Enchantments.FORTUNE, 2, false);
+		Map<Enchantment, Integer> enchantments = EnchantmentUtil.getEnchantments(itemStack);
+		assertTrue(enchantments.size() == 2);
+		assertTrue(enchantments.containsKey(Enchantments.EFFICIENCY));
+		assertTrue(enchantments.get(Enchantments.EFFICIENCY) == 3);
+		assertTrue(EnchantmentUtil.getEnchantmentLevel(itemStack, Enchantments.FORTUNE) == 2);
+		System.out.println(itemStack.getNBTData().get("ench").toString());
+	}
+
+	@Test
+	public void testRandomEnchantments() {
+		Random random = new Random();
+		VanillaMaterial[] materialList = new VanillaMaterial[] { VanillaMaterials.DIAMOND_PICKAXE, VanillaMaterials.LEATHER_BOOTS, VanillaMaterials.BOW, VanillaMaterials.GOLD_SWORD };
+		for (VanillaMaterial material : materialList) {
+			for (int level = 1; level < 31; ++level) {
+				ItemStack itemStack = new ItemStack(material.getMaterial(), 1);
+				boolean success = EnchantmentUtil.addRandomEnchantments(random, itemStack, level);
+				Map<Enchantment, Integer> enchantments = EnchantmentUtil.getEnchantments(itemStack);
+				assertTrue(success ^ (enchantments.size() == 0));
+				System.out.println("Enchanted " + material.toString() + " at level " + level);
+				for (Enchantment enchantment : enchantments.keySet()) {
+					assertTrue(enchantment.canEnchant(material));
+					System.out.println("  " + enchantment.getName() + " " + enchantments.get(enchantment));
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
(addressing http://issues.spout.org/browse/VANILLA-111)
*Added EnchantmentUtil.getRandomEnchantmentLevel to generate random
    enchantment level
*Added EnchantmentUtil.addRandomEnchantments to add random enchantments
    to an ItemStack
*Logic for both basically copied from Minecraft 1.3.2 source
*Fixed bug in Enchantments.values(), which was assuming the enchantment
    ids were consecutive
*Fixed bug in EnchantmentUtil.addEnchantment etc, which weren't putting
    the NBT data in the correct format
    (http://www.minecraftwiki.net/wiki/Player.dat_Format#Item_structure)
*Fixed bug in ToolEnchantment.canEnchant (returned true on bows and
    swords)
*Added tests EnchantmentTest and EnchantmentUtilTest
*Changed "enchantment level" to "power level" in places to distinguish
    between the power level of an enchantment (I, II, III, IV, V) and
    the enchantment level displayed in the enchantment interface (1 to
    30)
Signed-off-by: stewbasic stewbasic@gmail.com
