### PR TITLE
Fixed brewing stand output index check

### DIFF
--- a/src/main/java/org/spout/vanilla/inventory/block/BrewingStandInventory.java
+++ b/src/main/java/org/spout/vanilla/inventory/block/BrewingStandInventory.java
@@ -44,8 +44,8 @@ public class BrewingStandInventory extends Inventory implements VanillaInventory
 	 * @return {@link ItemStack} in the output
 	 */
 	public ItemStack getOutput(int index) {
-		if (index < 0 || index > 3) {
-			throw new IllegalArgumentException("The output index of the brewing stand must be between 0 and 3.");
+		if (index < 0 || index > 2) {
+			throw new IllegalArgumentException("The output index of the brewing stand must be between 0 and 2.");
 		}
 		return getItem(index);
 	}


### PR DESCRIPTION
There are only three outputs, so it should only be 0, 1, or 2

Signed-off-by: Jack Huey kitskub@gmail.com
