### PR TITLE
Added /plugins-tofile [filename].

### DIFF
--- a/src/main/java/org/spout/vanilla/command/TestCommands.java
+++ b/src/main/java/org/spout/vanilla/command/TestCommands.java
@@ -371,6 +371,10 @@ public class TestCommands {
      * Well atleast some
      */
     public String replaceInvalidCharsWin(String s) {
-        return s.replaceAll("[\\/:*?\"<>|]", "-");
+        if(System.getProperty("os.name").toLowerCase().indexOf("win") >= 0){
+            return s.replaceAll("[\\/:*?\"<>|]", "-");
+        }else{
+            return s;
+        }
     }
 }

--- a/src/main/java/org/spout/vanilla/command/TestCommands.java
+++ b/src/main/java/org/spout/vanilla/command/TestCommands.java
@@ -26,6 +26,13 @@
  */
 package org.spout.vanilla.command;
 
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.List;
 import java.util.Set;
 
@@ -44,6 +51,7 @@ import org.spout.api.geo.World;
 import org.spout.api.geo.cuboid.Block;
 import org.spout.api.geo.cuboid.Chunk;
 import org.spout.api.geo.discrete.Point;
+import org.spout.api.plugin.Plugin;
 import org.spout.api.protocol.NetworkSynchronizer;
 
 import org.spout.vanilla.VanillaPlugin;
@@ -262,4 +270,107 @@ public class TestCommands {
 			source.sendMessage("Chunk lighting is being initialized");
 		}
 	}
+	
+    @Command(aliases = "plugins-tofile", usage = "[filename]", desc = "Creates a file containing all loaded plugins and their version", min = 0, max = 1)
+    @CommandPermissions("vanilla.command.plugin.details")
+    public void getPluginDetails(CommandContext args, CommandSource source) throws CommandException {
+
+        // File and filename
+        String filename = "";
+        String standpath = "plugins/Vanilla/pluginreports";
+        File file = null;
+
+        // Getting date
+        DateFormat dateFormat = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss");
+        Date date = new Date();
+        String parse = dateFormat.format(date);
+
+        // Create file with passed filename or current date and time as name
+        if(args.length() == 1){
+            filename = args.getString(0);
+            file = new File(standpath.concat("/" + replaceInvalidCharsWin(filename)));
+        }else{
+            file = new File(standpath.concat("/" + replaceInvalidCharsWin(parse)).concat(".txt"));
+        }
+
+        // Delete the file if existent
+        if(file.exists()){
+            file.delete();
+        }
+
+        // Create a new file
+        try{
+            new File("plugins/Vanilla/pluginreports").mkdirs();
+            file.createNewFile();
+        }catch (IOException e){
+            throw new CommandException("Couldn't create output file!");
+        }
+
+        String linesep = System.getProperty("line.separator");
+
+        // Content Builder
+        StringBuilder sbuild = new StringBuilder();
+        sbuild.append("# This file was created on the " + dateFormat.format(date).concat(linesep));
+        sbuild.append("# Plugin Name | Version | Authors".concat(linesep));
+
+        // Plugins to write down
+        List<Plugin> plugins = Spout.getEngine().getPluginManager().getPlugins();
+
+        // Getting plugin informations
+        for(Plugin plugin : plugins){
+            
+            // Name and Version
+            sbuild.append(plugin.getName().concat(" | "));
+            sbuild.append(plugin.getDescription().getVersion());
+            
+            // Authors
+            List<String> authors = plugin.getDescription().getAuthors();
+            StringBuilder authbuilder = new StringBuilder();
+            if(authors != null && authors.size() > 0){
+                int size = authors.size();
+                int count = 0;
+                for(String s : authors){
+                    count++;
+                    if(count != size){
+                        authbuilder.append(s + ", ");
+                    }else{
+                        authbuilder.append(s);
+                    }
+                }
+                sbuild.append(" | ".concat(authbuilder.toString()).concat(linesep));
+            }else{
+                sbuild.append(linesep);
+            }
+        }
+
+        BufferedWriter writer = null;
+
+        // Write to file
+        if(file != null){
+            try{
+                writer = new BufferedWriter(new FileWriter(file));
+                writer.write(sbuild.toString());
+            }catch (IOException e){
+                throw new CommandException("Couldn't write to output file!");
+            }finally{
+                if(writer != null){
+                    try{
+                        writer.close();
+                    }catch (IOException e){
+                        e.printStackTrace();
+                    }
+                }
+            }
+        }
+        
+        source.sendMessage("Plugins-report successfully created! " + linesep +  "Stored in: " + standpath);
+    }
+
+    /**
+     * Replaces chars which are not allowed in filenames on windows with "-".
+     * Well atleast some
+     */
+    public String replaceInvalidCharsWin(String s) {
+        return s.replaceAll("[\\/:*?\"<>|]", "-");
+    }
 }


### PR DESCRIPTION
This command outputs a file having informations about all loaded plugins. 
The report is stored in plugins/Vanilla/pluginreports. 
The commadsource can define the filename of the report but if no filename 
was passed up on execution, then the current date and time is taken as the filename for the report.

The informations stored into the report are: name, version and authors(if info available).

An example outputfile looks like this:
http://www.hastebin.com/metukahupe.1c

Signed-off-by: Luca Moser moser.luca@gmail.com
