### PR TITLE
Add snow levels in code + Edit camera speed

### DIFF
--- a/src/main/java/org/spout/vanilla/VanillaListener.java
+++ b/src/main/java/org/spout/vanilla/VanillaListener.java
@@ -28,6 +28,7 @@ package org.spout.vanilla;
 
 import org.spout.api.Client;
 import org.spout.api.Spout;
+import org.spout.api.component.components.CameraComponent;
 import org.spout.api.entity.Player;
 import org.spout.api.event.EventHandler;
 import org.spout.api.event.Listener;
@@ -85,6 +86,9 @@ public class VanillaListener implements Listener {
 		player.add(HUDComponent.class).openHUD();
 		player.add(PlayerInventory.class);
 		player.add(WindowHolder.class);
+		
+		CameraComponent camera = player.get(CameraComponent.class);
+		camera.setSpeed(10f);
 	}
 
 	@EventHandler

--- a/src/main/java/org/spout/vanilla/material/block/misc/Snow.java
+++ b/src/main/java/org/spout/vanilla/material/block/misc/Snow.java
@@ -47,24 +47,26 @@ public class Snow extends GroundAttachable implements DynamicMaterial, Initializ
 	
 	static {
 		SNOW[0] = new Snow("Snow", 78);
-		SNOW[1] = new Snow("Snow_1", 1, SNOW[0], "model://Vanilla/resources/materials/block/solid/snowblock/snowblock.spm");
-		SNOW[2] = new Snow("Snow_2", 2, SNOW[0], "model://Vanilla/resources/materials/block/solid/snowblock/snowblock.spm");
-		SNOW[3] = new Snow("Snow_3", 3, SNOW[0], "model://Vanilla/resources/materials/block/solid/snowblock/snowblock.spm");
-		SNOW[4] = new Snow("Snow_4", 4, SNOW[0], "model://Vanilla/resources/materials/block/solid/snowblock/snowblock.spm");
-		SNOW[5] = new Snow("Snow_5", 5, SNOW[0], "model://Vanilla/resources/materials/block/solid/snowblock/snowblock.spm");
-		SNOW[6] = new Snow("Snow_6", 6, SNOW[0], "model://Vanilla/resources/materials/block/solid/snowblock/snowblock.spm");
-		SNOW[7] = new Snow("Snow_7", 7, SNOW[0], "model://Vanilla/resources/materials/block/solid/snowblock/snowblock.spm");
+		SNOW[1] = new Snow("Snow_1", 1, SNOW[0], "model://Vanilla/resources/materials/block/nonsolid/snow/snow_1.spm");
+		SNOW[2] = new Snow("Snow_2", 2, SNOW[0], "model://Vanilla/resources/materials/block/nonsolid/snow/snow_2.spm");
+		SNOW[3] = new Snow("Snow_3", 3, SNOW[0], "model://Vanilla/resources/materials/block/nonsolid/snow/snow_3.spm");
+		SNOW[4] = new Snow("Snow_4", 4, SNOW[0], "model://Vanilla/resources/materials/block/nonsolid/snow/snow_4.spm");
+		SNOW[5] = new Snow("Snow_5", 5, SNOW[0], "model://Vanilla/resources/materials/block/nonsolid/snow/snow_5.spm");
+		SNOW[6] = new Snow("Snow_6", 6, SNOW[0], "model://Vanilla/resources/materials/block/nonsolid/snow/snow_6.spm");
+		SNOW[7] = new Snow("Snow_7", 7, SNOW[0], "model://Vanilla/resources/materials/block/nonsolid/snow/snow_7.spm");
 	}
 
 	public Snow(String name, int id) {
 		super((short) 0x07, name, id, "model://Vanilla/resources/materials/block/solid/snowblock/snowblock.spm");
-		this.setLiquidObstacle(false).setStepSound(SoundEffects.STEP_CLOTH).setHardness(0.1F).setResistance(0.2F).setTransparent();
-		this.setOcclusion((short) 0, BlockFace.BOTTOM);
+		this.setLiquidObstacle(false).setStepSound(SoundEffects.STEP_CLOTH).setHardness(0.1F).setResistance(0.2F).setOpaque();
 		this.addMiningType(ToolType.SPADE).setMiningLevel(ToolLevel.WOOD);
 	}
 	
 	private Snow(String name, int data, Snow parent, String model) {
 		super(name, SNOW[0].getId(), data, parent, model);
+		this.setLiquidObstacle(false).setStepSound(SoundEffects.STEP_CLOTH).setHardness(0.1F).setResistance(0.2F).setOpaque();
+		this.setOcclusion((short) 0, BlockFace.BOTTOM);
+		this.addMiningType(ToolType.SPADE).setMiningLevel(ToolLevel.WOOD);
 	}
 
 	@Override

--- a/src/main/resources/resources/materials/block/nonsolid/snow/snow_1.spm
+++ b/src/main/resources/resources/materials/block/nonsolid/snow/snow_1.spm
@@ -1,0 +1,2 @@
+Mesh: blockmesh://Vanilla/resources/materials/block/nonsolid/snow/snow_1.obj
+Material: material://Vanilla/resources/materials/terrain.smt

--- a/src/main/resources/resources/materials/block/nonsolid/snow/snow_2.spm
+++ b/src/main/resources/resources/materials/block/nonsolid/snow/snow_2.spm
@@ -1,0 +1,2 @@
+Mesh: blockmesh://Vanilla/resources/materials/block/nonsolid/snow/snow_2.obj
+Material: material://Vanilla/resources/materials/terrain.smt

--- a/src/main/resources/resources/materials/block/nonsolid/snow/snow_3.spm
+++ b/src/main/resources/resources/materials/block/nonsolid/snow/snow_3.spm
@@ -1,0 +1,2 @@
+Mesh: blockmesh://Vanilla/resources/materials/block/nonsolid/snow/snow_3.obj
+Material: material://Vanilla/resources/materials/terrain.smt

--- a/src/main/resources/resources/materials/block/nonsolid/snow/snow_4.spm
+++ b/src/main/resources/resources/materials/block/nonsolid/snow/snow_4.spm
@@ -1,0 +1,2 @@
+Mesh: blockmesh://Vanilla/resources/materials/block/nonsolid/snow/snow_4.obj
+Material: material://Vanilla/resources/materials/terrain.smt

--- a/src/main/resources/resources/materials/block/nonsolid/snow/snow_5.spm
+++ b/src/main/resources/resources/materials/block/nonsolid/snow/snow_5.spm
@@ -1,0 +1,2 @@
+Mesh: blockmesh://Vanilla/resources/materials/block/nonsolid/snow/snow_5.obj
+Material: material://Vanilla/resources/materials/terrain.smt

--- a/src/main/resources/resources/materials/block/nonsolid/snow/snow_6.spm
+++ b/src/main/resources/resources/materials/block/nonsolid/snow/snow_6.spm
@@ -1,0 +1,2 @@
+Mesh: blockmesh://Vanilla/resources/materials/block/nonsolid/snow/snow_6.obj
+Material: material://Vanilla/resources/materials/terrain.smt

--- a/src/main/resources/resources/materials/block/nonsolid/snow/snow_7.spm
+++ b/src/main/resources/resources/materials/block/nonsolid/snow/snow_7.spm
@@ -1,0 +1,2 @@
+Mesh: blockmesh://Vanilla/resources/materials/block/nonsolid/snow/snow_7.obj
+Material: material://Vanilla/resources/materials/terrain.smt


### PR DESCRIPTION
Snow levels are ready to be use. But in game, there's always the whole
snow block instead of 7 levels. To fix.

Camera speed multiplied by 10 for the tests.

PS : didn't know how to make 2 PR with one commit, so I did one with the two commits.

Signed-off-by: Thomas LAMSON tomlabete@numericable.fr
