### PR TITLE
Implemented BlockChangeCause for Form, Grow, Ignite and Remove

### DIFF
--- a/src/main/java/org/spout/vanilla/event/cause/BlockChangeCause.java
+++ b/src/main/java/org/spout/vanilla/event/cause/BlockChangeCause.java
@@ -1,0 +1,47 @@
+/*
+ * This file is part of Vanilla.
+ *
+ * Copyright (c) 2011-2012, VanillaDev <http://www.spout.org/>
+ * Vanilla is licensed under the SpoutDev License Version 1.
+ *
+ * Vanilla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In addition, 180 days after any changes are published, you can use the
+ * software, incorporating those changes, under the terms of the MIT license,
+ * as described in the SpoutDev License Version 1.
+ *
+ * Vanilla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License,
+ * the MIT license and the SpoutDev License Version 1 along with this program.
+ * If not, see <http://www.gnu.org/licenses/> for the GNU Lesser General Public
+ * License and see <http://www.spout.org/SpoutDevLicenseV1.txt> for the full license,
+ * including the MIT license.
+ */
+package org.spout.vanilla.event.cause;
+
+import org.spout.api.event.Cause;
+import org.spout.api.geo.cuboid.Block;
+
+public class BlockChangeCause implements Cause {
+	private final Block source;
+
+	public BlockChangeCause(Block block) {
+		source = block;
+	}
+
+	/**
+	 * The block which changed
+	 * @return the block which changed
+	 */
+	@Override
+	public Block getSource() {
+		return source;
+	}
+}

--- a/src/main/java/org/spout/vanilla/event/cause/BlockFormCause.java
+++ b/src/main/java/org/spout/vanilla/event/cause/BlockFormCause.java
@@ -1,0 +1,96 @@
+/*
+ * This file is part of Vanilla.
+ *
+ * Copyright (c) 2011-2012, VanillaDev <http://www.spout.org/>
+ * Vanilla is licensed under the SpoutDev License Version 1.
+ *
+ * Vanilla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In addition, 180 days after any changes are published, you can use the
+ * software, incorporating those changes, under the terms of the MIT license,
+ * as described in the SpoutDev License Version 1.
+ *
+ * Vanilla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License,
+ * the MIT license and the SpoutDev License Version 1 along with this program.
+ * If not, see <http://www.gnu.org/licenses/> for the GNU Lesser General Public
+ * License and see <http://www.spout.org/SpoutDevLicenseV1.txt> for the full license,
+ * including the MIT license.
+ */
+package org.spout.vanilla.event.cause;
+
+import org.spout.api.geo.cuboid.Block;
+
+/**
+ * Caused when a block is formed or spreads
+ * todo needs to be implemented
+ */
+public class BlockFormCause extends BlockChangeCause {
+	/**
+	 * The different causes why a Block is formed in the world.
+	 */
+	public enum FormCause {
+		/**
+		 * Block spread randomly
+		 */
+		SPREAD_RANDOM,
+		/**
+		 * Block spread from other block
+		 */
+		SPREAD_FROM,
+		/**
+		 * Block formed due to world conditions (for example Snow)
+		 */
+		FORMING,
+	}
+
+	private final FormCause formCause;
+	private final Block spreadFrom;
+
+	/**
+	 * Contains the formCause of the block which has formed in the world.
+	 * @param block which was formed
+	 * @param formCause which caused the block to be formed
+	 */
+	public BlockFormCause(Block block, FormCause formCause) {
+		super(block);
+		this.formCause = formCause;
+		this.spreadFrom = null;
+	}
+
+	/**
+	 * Contains the formCause of the block which has formed the world.
+	 * @param block which was formed
+	 * @param formCause which caused the block to be formed
+	 * @param spreadFrom the block from where the cause spread
+	 */
+	public BlockFormCause(Block block, FormCause formCause, Block spreadFrom) {
+		super(block);
+		this.formCause = formCause;
+		this.spreadFrom = spreadFrom;
+	}
+
+	/**
+	 * Gets the {@link org.spout.vanilla.event.cause.BlockFormCause.FormCause} which removed the block
+	 * @return the removeCause
+	 */
+	public FormCause getFormCause() {
+		return formCause;
+	}
+
+	/**
+	 * Block from which the spread occurred, only valid for SPREAD_FROM.
+	 * Note: Can be NULL
+	 * @return Block from which the spread occurred, NULL when not SPREAD_FROM
+	 */
+	public Block getSpreadFrom() {
+		return spreadFrom;
+	}
+}

--- a/src/main/java/org/spout/vanilla/event/cause/BlockGrowCause.java
+++ b/src/main/java/org/spout/vanilla/event/cause/BlockGrowCause.java
@@ -1,0 +1,43 @@
+/*
+ * This file is part of Vanilla.
+ *
+ * Copyright (c) 2011-2012, VanillaDev <http://www.spout.org/>
+ * Vanilla is licensed under the SpoutDev License Version 1.
+ *
+ * Vanilla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In addition, 180 days after any changes are published, you can use the
+ * software, incorporating those changes, under the terms of the MIT license,
+ * as described in the SpoutDev License Version 1.
+ *
+ * Vanilla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License,
+ * the MIT license and the SpoutDev License Version 1 along with this program.
+ * If not, see <http://www.gnu.org/licenses/> for the GNU Lesser General Public
+ * License and see <http://www.spout.org/SpoutDevLicenseV1.txt> for the full license,
+ * including the MIT license.
+ */
+package org.spout.vanilla.event.cause;
+
+import org.spout.api.geo.cuboid.Block;
+
+/**
+ * Caused when a block grows
+ * todo needs to be implemented
+ */
+public class BlockGrowCause extends BlockChangeCause {
+	/**
+	 * Caused when a block grows.
+	 * @param block which was formed
+	 */
+	public BlockGrowCause(Block block) {
+		super(block);
+	}
+}

--- a/src/main/java/org/spout/vanilla/event/cause/BlockIgniteCause.java
+++ b/src/main/java/org/spout/vanilla/event/cause/BlockIgniteCause.java
@@ -1,0 +1,105 @@
+/*
+ * This file is part of Vanilla.
+ *
+ * Copyright (c) 2011-2012, VanillaDev <http://www.spout.org/>
+ * Vanilla is licensed under the SpoutDev License Version 1.
+ *
+ * Vanilla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In addition, 180 days after any changes are published, you can use the
+ * software, incorporating those changes, under the terms of the MIT license,
+ * as described in the SpoutDev License Version 1.
+ *
+ * Vanilla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License,
+ * the MIT license and the SpoutDev License Version 1 along with this program.
+ * If not, see <http://www.gnu.org/licenses/> for the GNU Lesser General Public
+ * License and see <http://www.spout.org/SpoutDevLicenseV1.txt> for the full license,
+ * including the MIT license.
+ */
+package org.spout.vanilla.event.cause;
+
+import org.spout.api.entity.Entity;
+import org.spout.api.geo.cuboid.Block;
+
+/**
+ * Caused when a block is ignited
+ * todo needs be implemented
+ */
+public class BlockIgniteCause extends BlockChangeCause {
+	/**
+	 * The different causes why a Block was ignited.
+	 */
+	public enum IgniteCause {
+		/**
+		 * Block ignition caused by Lava
+		 */
+		LAVA,
+		/**
+		 * Block ignition caused by using the Lightener
+		 */
+		FLINT_AND_STEEL,
+		/**
+		 * Block ignition caused by dynamic spread of fire
+		 */
+		SPREAD,
+		/**
+		 * Block ignition caused by lightning
+		 */
+		LIGHTING,
+		/**
+		 * Block ignition caused by a fireball
+		 */
+		FIREBALL,
+	}
+
+	private final IgniteCause igniteCause;
+	private final Entity entity;
+
+	/**
+	 * Contains the igniteCause and an entity of the block which was ignited.
+	 * @param block which was ignited
+	 * @param igniteCause which caused the block to ignite
+	 * @param entity which ignited the block
+	 */
+	public BlockIgniteCause(Block block, IgniteCause igniteCause, Entity entity) {
+		super(block);
+		this.igniteCause = igniteCause;
+		this.entity = entity;
+	}
+
+	/**
+	 * Contains the igniteCause of the block which was ignited.
+	 * @param block which was ignited
+	 * @param igniteCause which caused the block to ignite
+	 */
+	public BlockIgniteCause(Block block, IgniteCause igniteCause) {
+		super(block);
+		this.igniteCause = igniteCause;
+		this.entity = null;
+	}
+
+	/**
+	 * Gets the {@link org.spout.vanilla.event.cause.BlockIgniteCause.IgniteCause} which ignited the block
+	 * @return the igniteCause
+	 */
+	public IgniteCause getIgniteCause() {
+		return igniteCause;
+	}
+
+	/**
+	 * Gets the entity which ignited the block if applicable.
+	 * NOTE: This can be NULL
+	 * @return the entity which ignited the block, can be NULL
+	 */
+	public Entity getEntity() {
+		return entity;
+	}
+}

--- a/src/main/java/org/spout/vanilla/event/cause/BlockRemoveCause.java
+++ b/src/main/java/org/spout/vanilla/event/cause/BlockRemoveCause.java
@@ -1,0 +1,77 @@
+/*
+ * This file is part of Vanilla.
+ *
+ * Copyright (c) 2011-2012, VanillaDev <http://www.spout.org/>
+ * Vanilla is licensed under the SpoutDev License Version 1.
+ *
+ * Vanilla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * In addition, 180 days after any changes are published, you can use the
+ * software, incorporating those changes, under the terms of the MIT license,
+ * as described in the SpoutDev License Version 1.
+ *
+ * Vanilla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License,
+ * the MIT license and the SpoutDev License Version 1 along with this program.
+ * If not, see <http://www.gnu.org/licenses/> for the GNU Lesser General Public
+ * License and see <http://www.spout.org/SpoutDevLicenseV1.txt> for the full license,
+ * including the MIT license.
+ */
+package org.spout.vanilla.event.cause;
+
+import org.spout.api.geo.cuboid.Block;
+
+/**
+ * Caused when a block fades, melts, disappears or decays
+ * todo needs to be implemented
+ */
+public class BlockRemoveCause extends BlockChangeCause {
+	/**
+	 * The different causes why a Block is removed from the world.
+	 */
+	public enum RemoveCause {
+		/**
+		 * Block faded
+		 */
+		FADE,
+		/**
+		 * Block melted
+		 */
+		MELT,
+		/**
+		 * Block disappeared
+		 */
+		DISAPPEAR,
+		/**
+		 * Block decayed
+		 */
+		DECAY,
+	}
+
+	private final RemoveCause removeCause;
+
+	/**
+	 * Contains the removeCause of the block which has removed from the world.
+	 * @param block which has removed
+	 * @param removeCause which caused the block to be removed
+	 */
+	public BlockRemoveCause(Block block, RemoveCause removeCause) {
+		super(block);
+		this.removeCause = removeCause;
+	}
+
+	/**
+	 * Gets the {@link org.spout.vanilla.event.cause.BlockRemoveCause.RemoveCause} which removed the block
+	 * @return the removeCause
+	 */
+	public RemoveCause getRemoveCause() {
+		return removeCause;
+	}
+}


### PR DESCRIPTION
Form =  Spread_Random, Spread_From, Forming
Grow
Ignite = Lava, Flint_and_Steel, Spread,  Lightning, Fireball
Remove = Fade, Melt, Disappear, Decay

all of those causes for the BlockChangeEvent still need to be implemented.

Signed-off-by: Don Redhorse dredhorse@breiden.net
