### PR TITLE
Another pass at entity health events.

### DIFF
--- a/src/main/java/org/spout/vanilla/command/AdministrationCommands.java
+++ b/src/main/java/org/spout/vanilla/command/AdministrationCommands.java
@@ -53,8 +53,8 @@ import org.spout.vanilla.configuration.VanillaConfiguration;
 import org.spout.vanilla.data.GameMode;
 import org.spout.vanilla.data.Time;
 import org.spout.vanilla.data.Weather;
+import org.spout.vanilla.event.cause.HealthChangeCause;
 import org.spout.vanilla.material.VanillaMaterials;
-import org.spout.vanilla.source.HealthChangeCause;
 
 public class AdministrationCommands {
 	private final VanillaPlugin plugin;

--- a/src/main/java/org/spout/vanilla/component/misc/HealthComponent.java
+++ b/src/main/java/org/spout/vanilla/component/misc/HealthComponent.java
@@ -47,16 +47,18 @@ import org.spout.vanilla.data.VanillaRenderMaterials;
 import org.spout.vanilla.data.VanillaData;
 import org.spout.vanilla.event.cause.DamageCause;
 import org.spout.vanilla.event.cause.DamageCause.DamageType;
+import org.spout.vanilla.event.cause.HealCause;
+import org.spout.vanilla.event.cause.HealthChangeCause;
 import org.spout.vanilla.event.cause.NullDamageCause;
 import org.spout.vanilla.event.entity.EntityAnimationEvent;
 import org.spout.vanilla.event.entity.EntityDamageEvent;
+import org.spout.vanilla.event.entity.EntityHealEvent;
+import org.spout.vanilla.event.entity.EntityHealthChangeEvent;
 import org.spout.vanilla.event.entity.EntityStatusEvent;
 import org.spout.vanilla.event.entity.VanillaEntityDeathEvent;
 import org.spout.vanilla.event.player.PlayerDeathEvent;
 import org.spout.vanilla.event.player.network.PlayerHealthEvent;
-import org.spout.vanilla.protocol.handler.player.EntityHealthChangeEvent;
 import org.spout.vanilla.protocol.msg.entity.EntityStatusMessage;
-import org.spout.vanilla.source.HealthChangeCause;
 
 /**
  * Component that adds a health-like attribute to resources.entities.
@@ -284,6 +286,26 @@ public class HealthComponent extends EntityComponent {
 	}
 
 	/**
+	 * Heals this entity
+	 * @param amount amount the entity will be healed by
+	 */
+	public void heal(int amount) {
+		heal(amount, HealCause.UNKNOWN);
+	}
+	
+	/**
+	 * Heals this entity with the given {@link HealCause} 
+	 * @param amount amount the entity will be healed by
+	 * @param cause cause of this entity being healed
+	 */
+	public void heal(int amount, HealCause cause) {
+		EntityHealEvent event = new EntityHealEvent(getOwner(), amount, cause);
+		Spout.getEngine().getEventManager().callEvent(event);
+		
+		setHealth(getHealth() - event.getHealAmount(), HealthChangeCause.HEAL);
+	}
+	
+	/**
 	 * Sets the health value to 0
 	 * @param cause of the change
 	 */
@@ -324,7 +346,7 @@ public class HealthComponent extends EntityComponent {
 	}
 
 	/**
-	 * Damages this entity with the given {@link DamageCause}.
+	 * Damages this entity
 	 * @param amount amount the entity will be damaged by, can be modified based on armor and enchantments
 	 */
 	public void damage(int amount) {

--- a/src/main/java/org/spout/vanilla/component/misc/HungerComponent.java
+++ b/src/main/java/org/spout/vanilla/component/misc/HungerComponent.java
@@ -41,17 +41,16 @@ import org.spout.api.gui.Widget;
 import org.spout.api.gui.component.RenderPartsHolderComponent;
 import org.spout.api.gui.render.RenderPart;
 import org.spout.api.math.Rectangle;
-
 import org.spout.vanilla.component.living.neutral.Human;
 import org.spout.vanilla.component.player.HUDComponent;
 import org.spout.vanilla.data.GameMode;
-import org.spout.vanilla.data.VanillaRenderMaterials;
 import org.spout.vanilla.data.VanillaData;
+import org.spout.vanilla.data.VanillaRenderMaterials;
 import org.spout.vanilla.event.cause.DamageCause.DamageType;
+import org.spout.vanilla.event.cause.HealCause;
 import org.spout.vanilla.event.cause.NullDamageCause;
 import org.spout.vanilla.event.player.network.PlayerHealthEvent;
 import org.spout.vanilla.material.VanillaMaterials;
-import org.spout.vanilla.source.HealthChangeCause;
 
 public class HungerComponent extends EntityComponent {
 	private Human human;
@@ -149,7 +148,7 @@ public class HungerComponent extends EntityComponent {
 				if (health < 20 && hunger > 17) {
 					timer -= dt;
 					if (timer <= 0) {
-						healthComponent.setHealth(health + 1, HealthChangeCause.REGENERATION);
+						healthComponent.heal(1, HealCause.REGENERATION);
 						timer = 4;
 					}
 				}

--- a/src/main/java/org/spout/vanilla/event/cause/HealCause.java
+++ b/src/main/java/org/spout/vanilla/event/cause/HealCause.java
@@ -1,0 +1,46 @@
+package org.spout.vanilla.event.cause;
+
+
+public enum HealCause {
+	/**
+	 * Health gained due to regeneration on peaceful mode.
+	 */
+ 	REGENERATION,
+ 	/**
+	 * Health gained due to regeneration from being satiated.
+	 */
+ 	SATIATED,
+ 	/**
+	 * Health gained from consumables.
+	 */
+ 	CONSUMABLE,
+ 	/**
+	 * Health gained by an Ender Dragon from an Ender Crystal.
+	 */
+ 	ENDER_CRYSTAL,
+ 	/**
+	 * Health gained from a potion.
+	 */
+ 	MAGIC,
+ 	/**
+	 * Health gained from the HoT effect of a potion.
+	 */
+ 	MAGIC_REGEN,
+ 	/**
+	 * Health gained by the Wither when it is spawning.
+	 */
+ 	WITHER_SPAWN,
+ 	/**
+	 * Health gained due to an unknown source.
+	 */
+ 	UNKNOWN;
+ 	
+ 	public boolean equals(HealCause... causes) {
+		for (HealCause cause : causes) {
+			if (equals(cause)) {
+				return true;
+			}
+		}
+		return false;
+	}
+}

--- a/src/main/java/org/spout/vanilla/event/cause/HealthChangeCause.java
+++ b/src/main/java/org/spout/vanilla/event/cause/HealthChangeCause.java
@@ -24,7 +24,8 @@
  * License and see <http://spout.in/licensev1> for the full license, including
  * the MIT license.
  */
-package org.spout.vanilla.source;
+package org.spout.vanilla.event.cause;
+
 
 /**
  * Represents the source of a health change.
@@ -40,13 +41,10 @@ public enum HealthChangeCause {
 	 */
 	DAMAGE,
 	/**
-	 * Health changed due to regeneration cycle.
+	 * Health changed due to being healed.
+	 * @see {@link HealCause}
 	 */
-	REGENERATION,
-	/**
-	 * Health changed due to eating.
-	 */
-	EATING,
+	HEAL,
 	/**
 	 * Health changed due to the entity spawning.
 	 */

--- a/src/main/java/org/spout/vanilla/event/entity/EntityDamageEvent.java
+++ b/src/main/java/org/spout/vanilla/event/entity/EntityDamageEvent.java
@@ -28,32 +28,28 @@ package org.spout.vanilla.event.entity;
 
 import org.spout.api.entity.Entity;
 import org.spout.api.event.HandlerList;
-import org.spout.api.event.entity.EntityEvent;
-
 import org.spout.vanilla.event.cause.DamageCause;
 import org.spout.vanilla.event.cause.DamageCause.DamageType;
+import org.spout.vanilla.event.cause.HealthChangeCause;
 import org.spout.vanilla.event.cause.NullDamageCause;
 
-public class EntityDamageEvent extends EntityEvent {
+public class EntityDamageEvent extends EntityHealthChangeEvent {
 	private static HandlerList handlers = new HandlerList();
-	private int damage;
 	private boolean hasSendHurtMessage = true;
-	private DamageCause<? extends Object> cause = new NullDamageCause(DamageType.UNKNOWN);
+	private final DamageCause<? extends Object> cause;
 
 	public EntityDamageEvent(Entity e, int damage) {
-		super(e);
-		this.damage = damage;
+		super(e, HealthChangeCause.DAMAGE, -damage);
+		this.cause = new NullDamageCause(DamageType.UNKNOWN);
 	}
 
 	public EntityDamageEvent(Entity e, int damage, DamageCause<?> cause) {
-		super(e);
-		this.damage = damage;
+		super(e, HealthChangeCause.DAMAGE, -damage);
 		this.cause = cause;
 	}
 
 	public EntityDamageEvent(Entity e, int damage, DamageCause<?> cause, boolean sendHurtMessage) {
-		super(e);
-		this.damage = damage;
+		super(e, HealthChangeCause.DAMAGE, -damage);
 		this.cause = cause;
 		this.hasSendHurtMessage = sendHurtMessage;
 	}
@@ -105,7 +101,7 @@ public class EntityDamageEvent extends EntityEvent {
 	 * @return The damage to the health component.
 	 */
 	public int getDamage() {
-		return damage;
+		return -getChange();
 	}
 
 	/**
@@ -113,7 +109,7 @@ public class EntityDamageEvent extends EntityEvent {
 	 * @param damage The amount of damage dealt.
 	 */
 	public void setDamage(int damage) {
-		this.damage = damage;
+		setChange(-damage);
 	}
 
 	@Override

--- a/src/main/java/org/spout/vanilla/event/entity/EntityHealEvent.java
+++ b/src/main/java/org/spout/vanilla/event/entity/EntityHealEvent.java
@@ -1,0 +1,59 @@
+package org.spout.vanilla.event.entity;
+
+import org.spout.api.entity.Entity;
+import org.spout.api.event.HandlerList;
+import org.spout.vanilla.event.cause.HealCause;
+import org.spout.vanilla.event.cause.HealthChangeCause;
+
+public class EntityHealEvent extends EntityHealthChangeEvent {
+	private static HandlerList handlers = new HandlerList();
+	private final HealCause cause;
+
+	public EntityHealEvent(Entity e, int heal) {
+		super(e, HealthChangeCause.HEAL, heal);
+		this.cause = HealCause.UNKNOWN;
+	}
+
+	public EntityHealEvent(Entity e, int heal, HealCause cause) {
+		super(e, HealthChangeCause.DAMAGE, heal);
+		this.cause = cause;
+	}
+
+	/**
+	 * Gets the type of damage. Defaults to UNKNOWN.
+	 * @return type
+	 */
+	public HealCause getHealCause() {
+		return cause;
+	}
+	
+	/**
+	 * Gets the damage dealt to the health component.
+	 * @return The damage to the health component.
+	 */
+	public int getHealAmount() {
+		return getChange();
+	}
+
+	/**
+	 * Sets the damage to be dealt to the health component.
+	 * @param damage The amount of damage dealt.
+	 */
+	public void setHealAmount(int amount) {
+		setChange(amount);
+	}
+
+	@Override
+	public void setCancelled(boolean cancelled) {
+		super.setCancelled(cancelled);
+	}
+
+	@Override
+	public HandlerList getHandlers() {
+		return handlers;
+	}
+
+	public static HandlerList getHandlerList() {
+		return handlers;
+	}
+}

--- a/src/main/java/org/spout/vanilla/event/entity/EntityHealthChangeEvent.java
+++ b/src/main/java/org/spout/vanilla/event/entity/EntityHealthChangeEvent.java
@@ -50,14 +50,13 @@
  * License and see <http://www.spout.org/SpoutDevLicenseV1.txt> for the full license,
  * including the MIT license.
  */
-package org.spout.vanilla.protocol.handler.player;
+package org.spout.vanilla.event.entity;
 
 import org.spout.api.entity.Entity;
 import org.spout.api.event.Cancellable;
 import org.spout.api.event.HandlerList;
 import org.spout.api.event.entity.EntityEvent;
-
-import org.spout.vanilla.source.HealthChangeCause;
+import org.spout.vanilla.event.cause.HealthChangeCause;
 
 /**
  * Called when an entity has a health change.<br/>

--- a/src/main/java/org/spout/vanilla/material/item/armor/Armor.java
+++ b/src/main/java/org/spout/vanilla/material/item/armor/Armor.java
@@ -58,7 +58,7 @@ public abstract class Armor extends VanillaItemMaterial implements Enchantable {
 		return protection;
 	}
 
-	public int getProtection(ItemStack item, DamageCause cause) {
+	public int getProtection(ItemStack item, DamageCause<?> cause) {
 		DamageType type = cause.getType();
 		int amount = 0;
 		int level = 0;

--- a/src/main/java/org/spout/vanilla/protocol/handler/player/PlayerStatusHandler.java
+++ b/src/main/java/org/spout/vanilla/protocol/handler/player/PlayerStatusHandler.java
@@ -36,10 +36,10 @@ import org.spout.api.protocol.MessageHandler;
 import org.spout.api.protocol.Session;
 
 import org.spout.vanilla.component.living.neutral.Human;
+import org.spout.vanilla.event.cause.HealthChangeCause;
 import org.spout.vanilla.event.player.PlayerRespawnEvent;
 import org.spout.vanilla.protocol.VanillaProtocol;
 import org.spout.vanilla.protocol.msg.player.PlayerStatusMessage;
-import org.spout.vanilla.source.HealthChangeCause;
 
 public class PlayerStatusHandler extends MessageHandler<PlayerStatusMessage> {
 	@Override


### PR DESCRIPTION
Found EntityHealthChangeEvent lost in the player protocol package, so I moved it to entity events. Changed DamageEvent to extend it, and created HealEvent extending it.

Signed-off-by: Charlotte Mattier halfbloodpokemon@gmail.com
