### PR TITLE
Write/read ItemStacks fully for parameters

### DIFF
--- a/src/main/java/org/spout/vanilla/protocol/ChannelBufferUtils.java
+++ b/src/main/java/org/spout/vanilla/protocol/ChannelBufferUtils.java
@@ -87,9 +87,7 @@ public final class ChannelBufferUtils {
 					break;
 				case Parameter.TYPE_ITEM:
 					ItemStack item = ((Parameter<ItemStack>) parameter).getValue();
-					buf.writeShort(item.getMaterial().getId());
-					buf.writeByte(item.getAmount());
-					buf.writeShort(item.getData());
+					writeItemStack(buf, item);
 					break;
 			}
 		}
@@ -126,11 +124,7 @@ public final class ChannelBufferUtils {
 					parameters.add(new Parameter<String>(type, index, readString(buf)));
 					break;
 				case Parameter.TYPE_ITEM:
-					int id = buf.readShort();
-					int count = buf.readByte();
-					short data = buf.readShort();
-					ItemStack item = new ItemStack(Material.get((short) id), data, count);
-					parameters.add(new Parameter<ItemStack>(type, index, item));
+					parameters.add(new Parameter<ItemStack>(type, index, readItemStack(buf)));
 					break;
 			}
 		}


### PR DESCRIPTION
The parameter is a full slot or itemstack type as of minecraft version 1.4.4
See http://wiki.vg/Entities#Entity_Metadata_Format, http://wiki.vg/Protocol_History#2012-11-14
