### PR TITLE
Refresh the client when broken blocks are cancelled via an interact event

### DIFF
--- a/src/main/java/org/spout/vanilla/protocol/handler/player/PlayerDiggingHandler.java
+++ b/src/main/java/org/spout/vanilla/protocol/handler/player/PlayerDiggingHandler.java
@@ -144,6 +144,9 @@ public final class PlayerDiggingHandler extends MessageHandler<PlayerDiggingMess
 		if (state == PlayerDiggingMessage.STATE_START_DIGGING) {
 			PlayerInteractEvent event = new PlayerInteractEvent(player, block.getPosition(), heldItem, Action.LEFT_CLICK, isInteractable, clickedFace);
 			if (Spout.getEngine().getEventManager().callEvent(event).isCancelled()) {
+				if (human.isCreative() || blockMaterial.getHardness() == 0.0f) {
+					session.send(false, new BlockChangeMessage(block, session.getPlayer().getNetworkSynchronizer().getRepositionManager()));
+				}
 				return;
 			}
 
@@ -195,12 +198,17 @@ public final class PlayerDiggingHandler extends MessageHandler<PlayerDiggingMess
 				}
 			}
 		} else if (state == PlayerDiggingMessage.STATE_DONE_DIGGING) {
-			if (!player.get(DiggingComponent.class).stopDigging(new Point(w, x, y, z)) || !isInteractable) {
+			DiggingComponent diggingComponent = player.get(DiggingComponent.class);
+
+			if (!diggingComponent.stopDigging(new Point(w, x, y, z)) || !isInteractable) {
+				if (!diggingComponent.isDigging()) {
+					session.send(false, new BlockChangeMessage(block, session.getPlayer().getNetworkSynchronizer().getRepositionManager()));
+				}
 				return;
 			}
 
 			if (player.getData().get(VanillaData.GAMEMODE).equals(GameMode.SURVIVAL)) {
-				long diggingTicks = player.get(DiggingComponent.class).getDiggingTicks();
+				long diggingTicks = diggingComponent.getDiggingTicks();
 				int damageDone;
 				int totalDamage;
 


### PR DESCRIPTION
Hello again

Currently when you break a block a `PlayerInteractEvent` is thrown and if this is not cancelled a `BlockChangeEvent` will be thrown (signalling the block break). This assumes instant break. In the event of normal digging, `PlayerInteractEvent` is thrown when started and a `BlockChangeEvent` is thrown once it finally breaks. This is of course as expected.

However in both of these cases if the `PlayerInteractEvent` is cancelled, the player will most likely be left with a broken block in their client. The server should send the correct block back to the client upon failure of breaking the block.

This commit sends the block back to the client under 2 circumstances:
- In the `STATE_START_DIGGING` dig state, when the `PlayerInteractEvent` is cancelled **AND** the block is instantly breakable (creative or hardness = 0)
- In the `STATE_DONE_DIGGING` dig state, when the digging check fails **AND** the server sees the player as not currently digging (e.g the `PlayerInteractEvent` from `STATE_START_DIGGING` was cancelled!)

This has been confirmed to work as one would expect in both creative (instantly breaking blocks) and survival modes (digging). 
