### PR TITLE
SkullBlocks and SignBases should not be opaque.

### DIFF
--- a/src/main/java/org/spout/vanilla/plugin/material/block/component/SignBase.java
+++ b/src/main/java/org/spout/vanilla/plugin/material/block/component/SignBase.java
@@ -48,7 +48,7 @@ import org.spout.vanilla.plugin.resources.VanillaMaterialModels;
 public abstract class SignBase extends AbstractAttachable implements InitializableMaterial, VanillaComplexMaterial {
 	public SignBase(String name, int id) {
 		super(name, id, VanillaMaterialModels.SIGN);
-		this.setAttachable(BlockFaces.NESWB).setHardness(1.0F).setResistance(1.6F).setOpacity((byte) 1);
+		this.setAttachable(BlockFaces.NESWB).setHardness(1.0F).setResistance(1.6F).setTransparent();
 	}
 
 	@Override

--- a/src/main/java/org/spout/vanilla/plugin/material/block/component/SkullBlock.java
+++ b/src/main/java/org/spout/vanilla/plugin/material/block/component/SkullBlock.java
@@ -47,12 +47,12 @@ public class SkullBlock extends ComponentMaterial implements Attachable {
 
 	private SkullBlock(String name, int id) {
 		super((short) 0x7, name, id, Skull.class, null);
-		this.setHardness(1.0F).setResistance(3.0F).setOpaque();
+		this.setHardness(1.0F).setResistance(3.0F).setTransparent();
 	}
 
 	private SkullBlock(String name, int data, SkullBlock parent) {
 		super(name, parent.getId(), data, parent, null);
-		this.setHardness(1.0F).setResistance(3.0F).setOpaque();
+		this.setHardness(1.0F).setResistance(3.0F).setTransparent();
 	}
 
 	@Override


### PR DESCRIPTION
Signed off by Adam Price apricefrench2d@gmail.com
SkullBlocks and SignBases were opaque, and caused grass to decay under them. This changes them to be transparent.
