### PR TITLE
Enchantment work

### DIFF
--- a/src/main/java/org/spout/vanilla/plugin/component/misc/LevelComponent.java
+++ b/src/main/java/org/spout/vanilla/plugin/component/misc/LevelComponent.java
@@ -69,7 +69,7 @@ public class LevelComponent extends EntityComponent {
 			return;
 		}
 
-		getData().put(VanillaData.EXPERIENCE_AMOUNT, experience);
+		getData().put(VanillaData.EXPERIENCE_AMOUNT, event.getNewExp());
 	}
 
 	/**

--- a/src/main/java/org/spout/vanilla/plugin/component/substance/material/EnchantmentTable.java
+++ b/src/main/java/org/spout/vanilla/plugin/component/substance/material/EnchantmentTable.java
@@ -27,24 +27,49 @@
 package org.spout.vanilla.plugin.component.substance.material;
 
 import org.spout.api.entity.Player;
-import org.spout.api.inventory.Inventory;
 
 import org.spout.vanilla.api.inventory.Container;
 
 import org.spout.vanilla.plugin.component.inventory.WindowHolder;
 import org.spout.vanilla.plugin.inventory.block.EnchantmentTableInventory;
 import org.spout.vanilla.plugin.inventory.window.block.EnchantmentTableWindow;
+import org.spout.vanilla.plugin.inventory.window.prop.EnchantmentTableProperty;
 
 public class EnchantmentTable extends ViewedBlockComponent implements Container {
 	private final EnchantmentTableInventory inventory = new EnchantmentTableInventory();
+	private final int[] levels = new int[3];
 
 	@Override
-	public Inventory getInventory() {
+	public EnchantmentTableInventory getInventory() {
 		return inventory;
+	}
+
+	@Override
+	public void onTick(float dt) {
+		EnchantmentTableInventory inventory = getInventory();
+		for (Player player : viewers) {
+			if (inventory.has()) {
+				for (int i = 0; i < levels.length; i++) {
+					player.get(WindowHolder.class).getActiveWindow().setProperty(i, levels[i]);
+				}
+			}
+		}
 	}
 
 	@Override
 	public void open(Player player) {
 		player.get(WindowHolder.class).openWindow(new EnchantmentTableWindow(player, inventory));
+		setSlotLevel(EnchantmentTableProperty.SLOT_1, 1);
+		setSlotLevel(EnchantmentTableProperty.SLOT_2, 15);
+		setSlotLevel(EnchantmentTableProperty.SLOT_3, 30);
+	}
+
+	/**
+	 * Sets the level of the enchantment in the given {@link EnchantmentTableProperty} slot.
+	 * @param slot Slot to set
+	 * @param level Level of the enchantment
+	 */
+	public void setSlotLevel(EnchantmentTableProperty slot, int level) {
+		levels[slot.getId()] = level;
 	}
 }

--- a/src/main/java/org/spout/vanilla/plugin/inventory/block/EnchantmentTableInventory.java
+++ b/src/main/java/org/spout/vanilla/plugin/inventory/block/EnchantmentTableInventory.java
@@ -29,9 +29,10 @@ package org.spout.vanilla.plugin.inventory.block;
 import org.spout.api.inventory.Inventory;
 import org.spout.api.inventory.ItemStack;
 
+import org.spout.vanilla.plugin.material.item.VanillaItemMaterial;
+
 /**
- * Represents a enchantment table inventory belonging to an enchantment table
- * entity.
+ * Represents a enchantment table inventory belonging to an enchantment table entity.
  */
 public class EnchantmentTableInventory extends Inventory {
 	private static final long serialVersionUID = 1L;
@@ -51,11 +52,15 @@ public class EnchantmentTableInventory extends Inventory {
 	}
 
 	/**
-	 * Returns the {@link ItemStack} in the enchantment slot; can
-	 * return null.
+	 * Returns the {@link ItemStack} in the enchantment slot; can return null.
 	 * @return ingredient item stack
 	 */
 	public ItemStack get() {
 		return get(SLOT);
+	}
+
+	@Override
+	public boolean canSet(int i, ItemStack item) {
+		return item.getMaterial() instanceof VanillaItemMaterial && ((VanillaItemMaterial) item.getMaterial()).isEnchantable();
 	}
 }

--- a/src/main/java/org/spout/vanilla/plugin/material/VanillaMaterials.java
+++ b/src/main/java/org/spout/vanilla/plugin/material/VanillaMaterials.java
@@ -214,6 +214,7 @@ import org.spout.vanilla.plugin.material.item.minecart.MinecartItem;
 import org.spout.vanilla.plugin.material.item.minecart.PoweredMinecartItem;
 import org.spout.vanilla.plugin.material.item.minecart.StorageMinecartItem;
 import org.spout.vanilla.plugin.material.item.misc.BlazeRod;
+import org.spout.vanilla.plugin.material.item.misc.Book;
 import org.spout.vanilla.plugin.material.item.misc.BottleOEnchanting;
 import org.spout.vanilla.plugin.material.item.misc.Clay;
 import org.spout.vanilla.plugin.material.item.misc.Coal;
@@ -244,7 +245,6 @@ import org.spout.vanilla.plugin.material.item.tool.weapon.Sword;
 import org.spout.vanilla.plugin.material.map.Map;
 import org.spout.vanilla.plugin.resources.VanillaMaterialModels;
 
-// TODO: Remove all casts and separate remaining "set" methods out into each material's init() method
 public final class VanillaMaterials {
 	public static final BlockMaterial AIR = BlockMaterial.AIR;
 	public static final Stone STONE = new Stone("Stone", 1);
@@ -465,7 +465,7 @@ public final class VanillaMaterials {
 	public static final Bow BOW = new Bow("Bow", 261, (short) 385);
 	public static final VanillaItemMaterial ARROW = new VanillaItemMaterial("Arrow", 262, null);
 	public static final FishingRod FISHING_ROD = new FishingRod("Fishing Rod", 346, (short) 65);
-	public static final CarrotOnAStick CARROT_ON_A_STICK = new CarrotOnAStick("Carrot on a Stick", 398, (short) 25); //TODO: Check dur value
+	public static final CarrotOnAStick CARROT_ON_A_STICK = new CarrotOnAStick("Carrot on a Stick", 398, (short) 26);
 	// == Buckets=
 	public static final EmptyBucket BUCKET = new EmptyBucket("Bucket", 325);
 	public static final FullBucket WATER_BUCKET = new FullBucket("Water Bucket", 326, WATER);
@@ -502,7 +502,7 @@ public final class VanillaMaterials {
 	public static final VanillaItemMaterial CLAY_BRICK = new VanillaItemMaterial("Brick", 336, null);
 	public static final BlockItem SUGAR_CANE = new BlockItem("Sugar Cane", 338, VanillaMaterials.SUGAR_CANE_BLOCK, null);
 	public static final VanillaItemMaterial PAPER = new VanillaItemMaterial("Paper", 339, null);
-	public static final VanillaItemMaterial BOOK = new VanillaItemMaterial("Book", 340, null);
+	public static final Book BOOK = new Book("Book", 340, null);
 	public static final VanillaItemMaterial BOOK_AND_QUILL = new VanillaItemMaterial("Book and Quill", 386, null);
 	public static final VanillaItemMaterial WRITTEN_BOOK = new VanillaItemMaterial("Written Book", 387, null);
 	public static final VanillaItemMaterial SLIMEBALL = new VanillaItemMaterial("Slimeball", 341, null);

--- a/src/main/java/org/spout/vanilla/plugin/material/item/VanillaItemMaterial.java
+++ b/src/main/java/org/spout/vanilla/plugin/material/item/VanillaItemMaterial.java
@@ -38,6 +38,7 @@ public class VanillaItemMaterial extends Material implements VanillaMaterial {
 	private final int minecraftId;
 	private int meleeDamage = 1;
 	private final Vector2 pos;
+	private int enchantability;
 
 	public VanillaItemMaterial(String name, int id, Vector2 pos) {
 		super(name);
@@ -55,6 +56,30 @@ public class VanillaItemMaterial extends Material implements VanillaMaterial {
 		super(name, data, parent);
 		this.minecraftId = id;
 		this.pos = pos;
+	}
+
+	/**
+	 * Gets the enchantability of this item material to use in the process of enchanting
+	 * @return Enchantability level of this item material
+	 */
+	public int getEnchantability() {
+		return enchantability;
+	}
+
+	/**
+	 * Gets whether this item material is enchantable (has an enchantability greater than 0)
+	 * @return true if this item material's enchantability is greater than 0
+	 */
+	public boolean isEnchantable() {
+		return enchantability > 0;
+	}
+
+	/**
+	 * Sets the enchantability of this item material
+	 * @param enchantability Enchantability to set
+	 */
+	public void setEnchantability(int enchantability) {
+		this.enchantability = enchantability;
 	}
 
 	@Override

--- a/src/main/java/org/spout/vanilla/plugin/material/item/armor/Armor.java
+++ b/src/main/java/org/spout/vanilla/plugin/material/item/armor/Armor.java
@@ -29,17 +29,14 @@ package org.spout.vanilla.plugin.material.item.armor;
 import org.spout.api.inventory.ItemStack;
 import org.spout.api.math.Vector2;
 
-import org.spout.vanilla.api.material.item.Enchantable;
-
 import org.spout.vanilla.plugin.event.cause.DamageCause;
 import org.spout.vanilla.plugin.event.cause.DamageCause.DamageType;
 import org.spout.vanilla.plugin.material.enchantment.Enchantment;
 import org.spout.vanilla.plugin.material.enchantment.Enchantments;
 import org.spout.vanilla.plugin.material.item.VanillaItemMaterial;
 
-public abstract class Armor extends VanillaItemMaterial implements Enchantable {
+public abstract class Armor extends VanillaItemMaterial {
 	private int protection;
-	private int enchantability;
 	private short durability;
 
 	protected Armor(String name, int id, short durability, Vector2 pos) {
@@ -91,15 +88,5 @@ public abstract class Armor extends VanillaItemMaterial implements Enchantable {
 	@Override
 	public boolean hasNBTData() {
 		return true;
-	}
-
-	@Override
-	public int getEnchantability() {
-		return enchantability;
-	}
-
-	@Override
-	public void setEnchantability(int enchantability) {
-		this.enchantability = enchantability;
 	}
 }

--- a/src/main/java/org/spout/vanilla/plugin/material/item/armor/chain/ChainArmor.java
+++ b/src/main/java/org/spout/vanilla/plugin/material/item/armor/chain/ChainArmor.java
@@ -33,6 +33,6 @@ import org.spout.vanilla.plugin.material.item.armor.Armor;
 public abstract class ChainArmor extends Armor {
 	protected ChainArmor(String name, int id, short durability, Vector2 pos) {
 		super(name, id, durability, pos);
-		this.setEnchantability(12);
+		setEnchantability(12);
 	}
 }

--- a/src/main/java/org/spout/vanilla/plugin/material/item/armor/diamond/DiamondArmor.java
+++ b/src/main/java/org/spout/vanilla/plugin/material/item/armor/diamond/DiamondArmor.java
@@ -33,6 +33,6 @@ import org.spout.vanilla.plugin.material.item.armor.Armor;
 public abstract class DiamondArmor extends Armor {
 	protected DiamondArmor(String name, int id, short durability, Vector2 pos) {
 		super(name, id, durability, pos);
-		this.setEnchantability(10);
+		setEnchantability(10);
 	}
 }

--- a/src/main/java/org/spout/vanilla/plugin/material/item/armor/gold/GoldArmor.java
+++ b/src/main/java/org/spout/vanilla/plugin/material/item/armor/gold/GoldArmor.java
@@ -33,6 +33,6 @@ import org.spout.vanilla.plugin.material.item.armor.Armor;
 public abstract class GoldArmor extends Armor {
 	protected GoldArmor(String name, int id, short durability, Vector2 pos) {
 		super(name, id, durability, pos);
-		this.setEnchantability(25);
+		setEnchantability(25);
 	}
 }

--- a/src/main/java/org/spout/vanilla/plugin/material/item/armor/iron/IronArmor.java
+++ b/src/main/java/org/spout/vanilla/plugin/material/item/armor/iron/IronArmor.java
@@ -33,6 +33,6 @@ import org.spout.vanilla.plugin.material.item.armor.Armor;
 public abstract class IronArmor extends Armor {
 	protected IronArmor(String name, int id, short durability, Vector2 pos) {
 		super(name, id, durability, pos);
-		this.setEnchantability(9);
+		setEnchantability(9);
 	}
 }

--- a/src/main/java/org/spout/vanilla/plugin/material/item/armor/leather/LeatherArmor.java
+++ b/src/main/java/org/spout/vanilla/plugin/material/item/armor/leather/LeatherArmor.java
@@ -33,6 +33,6 @@ import org.spout.vanilla.plugin.material.item.armor.Armor;
 public abstract class LeatherArmor extends Armor {
 	protected LeatherArmor(String name, int id, short durability, Vector2 pos) {
 		super(name, id, durability, pos);
-		this.setEnchantability(15);
+		setEnchantability(15);
 	}
 }

--- a/src/main/java/org/spout/vanilla/plugin/material/item/misc/Book.java
+++ b/src/main/java/org/spout/vanilla/plugin/material/item/misc/Book.java
@@ -24,21 +24,15 @@
  * License and see <http://spout.in/licensev1> for the full license, including
  * the MIT license.
  */
-package org.spout.vanilla.api.material.item;
+package org.spout.vanilla.plugin.material.item.misc;
 
-/**
- * Represents an item material that can be enchanted
- */
-public interface Enchantable {
-	/**
-	 * Gets the enchantability of this item material to use in the process of enchanting
-	 * @return Enchantability level of this item material
-	 */
-	public int getEnchantability();
+import org.spout.api.math.Vector2;
 
-	/**
-	 * Sets the enchantability of this item material
-	 * @param enchantability Enchantability to set
-	 */
-	public void setEnchantability(int enchantability);
+import org.spout.vanilla.plugin.material.item.VanillaItemMaterial;
+
+public class Book extends VanillaItemMaterial {
+	public Book(String name, int id, Vector2 pos) {
+		super(name, id, pos);
+		setEnchantability(1);
+	}
 }

--- a/src/main/java/org/spout/vanilla/plugin/material/item/misc/EnchantedBook.java
+++ b/src/main/java/org/spout/vanilla/plugin/material/item/misc/EnchantedBook.java
@@ -26,24 +26,10 @@
  */
 package org.spout.vanilla.plugin.material.item.misc;
 
-import org.spout.vanilla.api.material.item.Enchantable;
-
 import org.spout.vanilla.plugin.material.item.VanillaItemMaterial;
 
-public class EnchantedBook extends VanillaItemMaterial implements Enchantable {
-	private int enchantability;
-
+public class EnchantedBook extends VanillaItemMaterial {
 	public EnchantedBook(String name, int id) {
 		super(name, id, null);
-	}
-
-	@Override
-	public int getEnchantability() {
-		return enchantability;
-	}
-
-	@Override
-	public void setEnchantability(int enchantability) {
-		this.enchantability = enchantability;
 	}
 }

--- a/src/main/java/org/spout/vanilla/plugin/material/item/tool/Tool.java
+++ b/src/main/java/org/spout/vanilla/plugin/material/item/tool/Tool.java
@@ -37,8 +37,6 @@ import org.spout.api.material.BlockMaterial;
 import org.spout.api.math.Vector2;
 import org.spout.api.util.flag.Flag;
 
-import org.spout.vanilla.api.material.item.Enchantable;
-
 import org.spout.vanilla.plugin.component.living.hostile.Silverfish;
 import org.spout.vanilla.plugin.component.living.hostile.Skeleton;
 import org.spout.vanilla.plugin.component.living.hostile.Spider;
@@ -49,10 +47,9 @@ import org.spout.vanilla.plugin.material.enchantment.Enchantment;
 import org.spout.vanilla.plugin.material.enchantment.Enchantments;
 import org.spout.vanilla.plugin.material.item.VanillaItemMaterial;
 
-public abstract class Tool extends VanillaItemMaterial implements Enchantable {
+public abstract class Tool extends VanillaItemMaterial {
 	private final Random rand = new Random();
 	private short durability;
-	private int enchantability;
 	private Map<BlockMaterial, Float> strengthModifiers = new HashMap<BlockMaterial, Float>();
 	private ToolType toolType;
 
@@ -104,16 +101,6 @@ public abstract class Tool extends VanillaItemMaterial implements Enchantable {
 
 	public Set<BlockMaterial> getStrengthModifiedBlocks() {
 		return strengthModifiers.keySet();
-	}
-
-	@Override
-	public int getEnchantability() {
-		return enchantability;
-	}
-
-	@Override
-	public void setEnchantability(int enchantability) {
-		this.enchantability = enchantability;
 	}
 
 	@Override


### PR DESCRIPTION
-Placing an item in the enchantment table now displays 3 levels in the enchantment GUI (they cannot be clicked or interacted with in any form at the moment)
-All items have been given an "enchantability" level instead of using an Enchantable interface. This allows plugins to easily allow items that normally would not be enchantable to be enchantable. Items with an enchantability of 0 (default) cannot be placed in the enchantment table inventory slot. Enchantability is used in the process of calculating enchantments for an item (also not started yet).
