### PR TITLE
Stopped resetting of gamemode during login.

### DIFF
--- a/src/main/java/org/spout/vanilla/plugin/protocol/VanillaNetworkSynchronizer.java
+++ b/src/main/java/org/spout/vanilla/plugin/protocol/VanillaNetworkSynchronizer.java
@@ -422,6 +422,7 @@ public class VanillaNetworkSynchronizer extends NetworkSynchronizer implements P
 
 	@Override
 	protected void worldChanged(World world) {
+		GameMode gamemode;
 		WorldConfigurationNode node = VanillaConfiguration.WORLDS.get(world);
 		maxY = node.MAX_Y.getInt() & (~Chunk.BLOCKS.MASK);
 		minY = node.MIN_Y.getInt() & (~Chunk.BLOCKS.MASK);
@@ -430,7 +431,12 @@ public class VanillaNetworkSynchronizer extends NetworkSynchronizer implements P
 		highY = minY + stepY;
 		lastY = Integer.MAX_VALUE;
 
-		GameMode gamemode = world.getComponentHolder().getData().get(VanillaData.GAMEMODE);
+		if (player.getData().get("game_mode") == null) {
+			gamemode = world.getComponentHolder().getData().get(VanillaData.GAMEMODE);
+			player.getData().put(VanillaData.GAMEMODE, gamemode);
+		} else {
+			gamemode = player.getData().get(VanillaData.GAMEMODE);
+		}
 		Difficulty difficulty = world.getComponentHolder().getData().get(VanillaData.DIFFICULTY);
 		Dimension dimension = world.getComponentHolder().getData().get(VanillaData.DIMENSION);
 		WorldType worldType = world.getComponentHolder().getData().get(VanillaData.WORLD_TYPE);


### PR DESCRIPTION
The way it was prior to this was basically always take the World's gamemode specified in worlds.yml and apply it to the player when they log in. This change makes it so if its null, apply the world's default gamemode but if they have one specified VanillaData.GAMEMODE (Creative, Survival, Adventure) then to use that instead.
Signed-off-by: Steven Downer grinch@outlook.com
