### PR TITLE
Fix how we handle held items, and armor slot changes to other clients.

### DIFF
--- a/src/main/java/org/spout/vanilla/api/event/entity/EntityEquipmentEvent.java
+++ b/src/main/java/org/spout/vanilla/api/event/entity/EntityEquipmentEvent.java
@@ -32,6 +32,10 @@ import org.spout.api.event.entity.EntityEvent;
 import org.spout.api.inventory.ItemStack;
 import org.spout.api.protocol.event.ProtocolEvent;
 
+/**
+ * Represents an entity equiping an item.<br/>
+ * By default, slot 0 is for a held-item change, and slots 1-4 are for armor.<br/>
+ */
 public class EntityEquipmentEvent extends EntityEvent implements ProtocolEvent {
 	private static final HandlerList handlers = new HandlerList();
 	private int slot;

--- a/src/main/java/org/spout/vanilla/plugin/component/inventory/PlayerInventory.java
+++ b/src/main/java/org/spout/vanilla/plugin/component/inventory/PlayerInventory.java
@@ -32,7 +32,7 @@ import org.spout.api.inventory.ItemStack;
 
 import org.spout.vanilla.plugin.data.VanillaData;
 import org.spout.vanilla.plugin.inventory.block.ChestInventory;
-import org.spout.vanilla.plugin.inventory.player.PlayerArmorInventory;
+import org.spout.vanilla.plugin.inventory.entity.EntityArmorInventory;
 import org.spout.vanilla.plugin.inventory.player.PlayerCraftingInventory;
 import org.spout.vanilla.plugin.inventory.player.PlayerMainInventory;
 import org.spout.vanilla.plugin.inventory.player.PlayerQuickbar;
@@ -61,7 +61,7 @@ public class PlayerInventory extends EntityComponent {
 	 * Gets the armor inventory of this player inventory
 	 * @return an Inventory with the armor items
 	 */
-	public PlayerArmorInventory getArmor() {
+	public EntityArmorInventory getArmor() {
 		return getData().get(VanillaData.ARMOR_INVENTORY);
 	}
 

--- a/src/main/java/org/spout/vanilla/plugin/component/misc/HealthComponent.java
+++ b/src/main/java/org/spout/vanilla/plugin/component/misc/HealthComponent.java
@@ -72,7 +72,7 @@ import org.spout.vanilla.plugin.component.substance.XPOrb;
 import org.spout.vanilla.plugin.configuration.VanillaConfiguration;
 import org.spout.vanilla.plugin.data.VanillaData;
 import org.spout.vanilla.plugin.data.VanillaRenderMaterials;
-import org.spout.vanilla.plugin.inventory.player.PlayerArmorInventory;
+import org.spout.vanilla.plugin.inventory.entity.EntityArmorInventory;
 import org.spout.vanilla.plugin.inventory.player.PlayerCraftingInventory;
 import org.spout.vanilla.plugin.inventory.player.PlayerMainInventory;
 import org.spout.vanilla.plugin.inventory.player.PlayerQuickbar;
@@ -262,7 +262,7 @@ public class HealthComponent extends EntityComponent {
 		PlayerInventory playerInventory = owner.get(PlayerInventory.class);
 		if (playerInventory != null) {
 			Set<ItemStack> toDrop = new HashSet<ItemStack>();
-			PlayerArmorInventory armorInventory = playerInventory.getArmor();
+			EntityArmorInventory armorInventory = playerInventory.getArmor();
 			PlayerCraftingInventory craftingGrid = playerInventory.getCraftingGrid();
 			PlayerMainInventory mainInventory = playerInventory.getMain();
 			PlayerQuickbar quickbar = playerInventory.getQuickbar();

--- a/src/main/java/org/spout/vanilla/plugin/data/VanillaData.java
+++ b/src/main/java/org/spout/vanilla/plugin/data/VanillaData.java
@@ -47,7 +47,7 @@ import org.spout.vanilla.plugin.inventory.block.BrewingStandInventory;
 import org.spout.vanilla.plugin.inventory.block.ChestInventory;
 import org.spout.vanilla.plugin.inventory.block.FurnaceInventory;
 import org.spout.vanilla.plugin.inventory.player.DropInventory;
-import org.spout.vanilla.plugin.inventory.player.PlayerArmorInventory;
+import org.spout.vanilla.plugin.inventory.entity.EntityArmorInventory;
 import org.spout.vanilla.plugin.inventory.player.PlayerCraftingInventory;
 import org.spout.vanilla.plugin.inventory.player.PlayerMainInventory;
 import org.spout.vanilla.plugin.inventory.player.PlayerQuickbar;
@@ -126,7 +126,7 @@ public class VanillaData {
 	// Inventory
 	public static final DefaultedKey<PlayerMainInventory> MAIN_INVENTORY = new DefaultedKeyFactory<PlayerMainInventory>("main", PlayerMainInventory.class);
 	public static final DefaultedKey<PlayerCraftingInventory> CRAFTING_INVENTORY = new DefaultedKeyFactory<PlayerCraftingInventory>("crafting", PlayerCraftingInventory.class);
-	public static final DefaultedKey<PlayerArmorInventory> ARMOR_INVENTORY = new DefaultedKeyFactory<PlayerArmorInventory>("armor", PlayerArmorInventory.class);
+	public static final DefaultedKey<EntityArmorInventory> ARMOR_INVENTORY = new DefaultedKeyFactory<EntityArmorInventory>("armor", EntityArmorInventory.class);
 	public static final DefaultedKey<PlayerQuickbar> QUICKBAR_INVENTORY = new DefaultedKeyFactory<PlayerQuickbar>("quickbar", PlayerQuickbar.class);
 	public static final DefaultedKey<ChestInventory> ENDER_CHEST_INVENTORY = new DefaultedKeyFactory<ChestInventory>("ender_chest_inventory", ChestInventory.class);
 	//Creature-specific

--- a/src/main/java/org/spout/vanilla/plugin/inventory/entity/EntityArmorInventory.java
+++ b/src/main/java/org/spout/vanilla/plugin/inventory/entity/EntityArmorInventory.java
@@ -24,8 +24,9 @@
  * License and see <http://spout.in/licensev1> for the full license, including
  * the MIT license.
  */
-package org.spout.vanilla.plugin.inventory.player;
+package org.spout.vanilla.plugin.inventory.entity;
 
+import org.spout.api.entity.Entity;
 import org.spout.api.entity.Player;
 import org.spout.api.inventory.Inventory;
 import org.spout.api.inventory.ItemStack;
@@ -40,34 +41,34 @@ import org.spout.vanilla.api.material.item.armor.Leggings;
 import org.spout.vanilla.plugin.protocol.msg.entity.EntityEquipmentMessage;
 
 /**
- * Represents the four armor slots on a {@link org.spout.vanilla.plugin.component.inventory.PlayerInventory}.
+ * Represents the four armor slots of an Entity's inventory.<br/>
  */
-public class PlayerArmorInventory extends Inventory {
+public class EntityArmorInventory extends Inventory {
 	private static final long serialVersionUID = 1L;
 	public static final int SIZE = 4;
 	public static final int BOOT_SLOT = 0, LEGGINGS_SLOT = 1, CHEST_PLATE_SLOT = 2, HELMET_SLOT = 3;
 
-	public PlayerArmorInventory() {
+	public EntityArmorInventory() {
 		super(SIZE);
 	}
 
 	/**
-	 * Informs a player of all the equipment (armor)
-	 * @param player to inform
+	 * Informs an entity of all the equipment (armor)
+	 * @param entity to inform
 	 */
-	public void updateSlots(Player player) {
+	public void updateSlots(Entity entity) {
 		for (int i = 0; i < this.size(); i++) {
-			updateSlot(i, get(i), player);
+			updateSlot(i, get(i), entity);
 		}
 	}
 
 	/**
-	 * Informs a player of a certain equipment (armor) change
+	 * Informs an entity of a certain equipment (armor) change
 	 * @param i - item slot index
 	 * @param item that the slot got set to
-	 * @param player to inform
+	 * @param entity to inform
 	 */
-	public static void updateSlot(int i, ItemStack item, Player player) {
+	public static void updateSlot(int i, ItemStack item, Entity entity) {
 		final int equip;
 		switch (i) {
 			case BOOT_SLOT:
@@ -85,7 +86,7 @@ public class PlayerArmorInventory extends Inventory {
 			default:
 				return;
 		}
-		player.getNetwork().callProtocolEvent(new EntityEquipmentEvent(player, equip, item));
+		entity.getNetwork().callProtocolEvent(new EntityEquipmentEvent(entity, equip, item), true);
 	}
 
 	@Override

--- a/src/main/java/org/spout/vanilla/plugin/inventory/player/PlayerQuickbar.java
+++ b/src/main/java/org/spout/vanilla/plugin/inventory/player/PlayerQuickbar.java
@@ -30,7 +30,9 @@ import org.spout.api.entity.Player;
 import org.spout.api.inventory.Inventory;
 import org.spout.api.inventory.ItemStack;
 
+import org.spout.vanilla.api.event.entity.EntityEquipmentEvent;
 import org.spout.vanilla.api.inventory.Slot;
+import org.spout.vanilla.plugin.protocol.msg.entity.EntityEquipmentMessage;
 
 public class PlayerQuickbar extends Inventory {
 	private static final long serialVersionUID = 1L;
@@ -56,10 +58,6 @@ public class PlayerQuickbar extends Inventory {
 	@SuppressWarnings("unused")
 	public void updateHeldItem(Player player) {
 		ItemStack item = this.get(this.selected);
-		//TODO: This needs implementation
-		// EntityEquipmentEvent does NOT WORK!
-		// Equipment messages with slots 0 - 3 are (now) reserved for armor slots
-		// Slot -1 and 4 both throw an index out of bounds exception on the client
-		// If someone finds out the new method of doing this, that would be great
+		player.getNetwork().callProtocolEvent(new EntityEquipmentEvent(player, EntityEquipmentMessage.HELD_SLOT, item), true);
 	}
 }

--- a/src/main/java/org/spout/vanilla/plugin/inventory/window/DefaultWindow.java
+++ b/src/main/java/org/spout/vanilla/plugin/inventory/window/DefaultWindow.java
@@ -38,7 +38,7 @@ import org.spout.api.math.Vector2;
 import org.spout.api.plugin.Platform;
 
 import org.spout.vanilla.plugin.component.inventory.PlayerInventory;
-import org.spout.vanilla.plugin.inventory.player.PlayerArmorInventory;
+import org.spout.vanilla.plugin.inventory.entity.EntityArmorInventory;
 import org.spout.vanilla.plugin.inventory.player.PlayerCraftingInventory;
 import org.spout.vanilla.plugin.inventory.util.InventoryConverter;
 
@@ -84,8 +84,8 @@ public class DefaultWindow extends Window {
 	@Override
 	public void onSlotSet(Inventory inventory, int slot, ItemStack item, ItemStack previous) {
 		super.onSlotSet(inventory, slot, item, previous);
-		if (inventory instanceof PlayerArmorInventory) {
-			PlayerArmorInventory.updateSlot(slot, item, getPlayer());
+		if (inventory instanceof EntityArmorInventory) {
+			EntityArmorInventory.updateSlot(slot, item, getPlayer());
 		}
 	}
 
@@ -98,9 +98,9 @@ public class DefaultWindow extends Window {
 		final PlayerInventory inventory = getPlayerInventory();
 
 		// Transferring to the armor slots
-		if (!(from instanceof PlayerArmorInventory)) {
+		if (!(from instanceof EntityArmorInventory)) {
 			// Transferring to the armor slots
-			final PlayerArmorInventory armor = inventory.getArmor();
+			final EntityArmorInventory armor = inventory.getArmor();
 			for (int i = 0; i < armor.size(); i++) {
 				if (armor.get(i) == null && armor.canSet(i, stack)) {
 					armor.set(i, ItemStack.cloneSpecial(stack));

--- a/src/main/java/org/spout/vanilla/plugin/protocol/entity/HumanEntityProtocol.java
+++ b/src/main/java/org/spout/vanilla/plugin/protocol/entity/HumanEntityProtocol.java
@@ -39,7 +39,7 @@ import org.spout.vanilla.api.inventory.Slot;
 
 import org.spout.vanilla.plugin.component.inventory.PlayerInventory;
 import org.spout.vanilla.plugin.component.living.neutral.Human;
-import org.spout.vanilla.plugin.inventory.player.PlayerArmorInventory;
+import org.spout.vanilla.plugin.inventory.entity.EntityArmorInventory;
 import org.spout.vanilla.plugin.protocol.ChannelBufferUtils;
 import org.spout.vanilla.plugin.protocol.msg.entity.EntityEquipmentMessage;
 import org.spout.vanilla.plugin.protocol.msg.player.pos.PlayerSpawnMessage;
@@ -72,31 +72,25 @@ public class HumanEntityProtocol extends VanillaEntityProtocol {
 
 		// Armor
 		PlayerInventory inventory = entity.get(PlayerInventory.class);
-		final ItemStack boots, leggings, chestplate, helmet;
+		final ItemStack boots, leggings, chestplate, helmet, held;
 		if (inventory == null) {
-			boots = leggings = chestplate = helmet = null;
+			boots = leggings = chestplate = helmet = held = null;
 		} else {
-			final PlayerArmorInventory armor = inventory.getArmor();
+			final EntityArmorInventory armor = inventory.getArmor();
 			boots = armor.getBoots();
 			leggings = armor.getLeggings();
 			chestplate = armor.getChestPlate();
 			helmet = armor.getHelmet();
+			held = inventory.getQuickbar().getSelectedSlot().get();
+		}
+		if (held != null) {
+			messages.add(new EntityEquipmentMessage(entity.getId(), EntityEquipmentMessage.HELD_SLOT, held));
 		}
 		messages.add(new EntityEquipmentMessage(entity.getId(), EntityEquipmentMessage.BOOTS_SLOT, boots));
 		messages.add(new EntityEquipmentMessage(entity.getId(), EntityEquipmentMessage.LEGGINGS_SLOT, leggings));
 		messages.add(new EntityEquipmentMessage(entity.getId(), EntityEquipmentMessage.CHESTPLATE_SLOT, chestplate));
 		messages.add(new EntityEquipmentMessage(entity.getId(), EntityEquipmentMessage.HELMET_SLOT, helmet));
 
-		// Held item
-		// TODO: Equipment message of slot 0 is no longer possible to use
-		// Something else needs to be used here!
-		/*
-		if (hand != null) {
-			messages.add(new EntityEquipmentMessage(entity.getId(), 0, hand.get()));
-		} else {
-			messages.add(new EntityEquipmentMessage(entity.getId(), 0, null));
-		}
-		*/
 		return messages;
 	}
 }

--- a/src/main/java/org/spout/vanilla/plugin/protocol/msg/entity/EntityEquipmentMessage.java
+++ b/src/main/java/org/spout/vanilla/plugin/protocol/msg/entity/EntityEquipmentMessage.java
@@ -32,10 +32,11 @@ import org.spout.api.inventory.ItemStack;
 import org.spout.api.util.SpoutToStringStyle;
 
 public final class EntityEquipmentMessage extends EntityMessage {
-	public static final int BOOTS_SLOT = 0;
-	public static final int LEGGINGS_SLOT = 1;
-	public static final int CHESTPLATE_SLOT = 2;
-	public static final int HELMET_SLOT = 3;
+	public static final int HELD_SLOT = 0;
+	public static final int BOOTS_SLOT = 1;
+	public static final int LEGGINGS_SLOT = 2;
+	public static final int CHESTPLATE_SLOT = 3;
+	public static final int HELMET_SLOT = 4;
 	private int slot;
 	private final ItemStack item;
 


### PR DESCRIPTION
Fixes Armor being sent to the incorrect slots on the client.
Enables held item slot being sent to the client properly, also sends it when the entity spawns.
refactored PlayerArmorInventory to EntityArmorInventory as other Entities will be getting this.

Signed-off-by: Nick Minkler sleaker@gmail.com
