### PR TITLE
Add canEquip to Materials

### DIFF
--- a/src/main/java/org/spout/vanilla/api/inventory/entity/ArmorInventory.java
+++ b/src/main/java/org/spout/vanilla/api/inventory/entity/ArmorInventory.java
@@ -29,12 +29,7 @@ package org.spout.vanilla.api.inventory.entity;
 import org.spout.api.entity.Entity;
 import org.spout.api.inventory.Inventory;
 import org.spout.api.inventory.ItemStack;
-import org.spout.api.material.Material;
-
-import org.spout.vanilla.api.material.item.armor.Boots;
-import org.spout.vanilla.api.material.item.armor.Chestplate;
-import org.spout.vanilla.api.material.item.armor.Helmet;
-import org.spout.vanilla.api.material.item.armor.Leggings;
+import org.spout.vanilla.api.material.VanillaMaterial;
 
 /**
  * Represents the four armor slots of an Entity's inventory.<br/>
@@ -67,24 +62,12 @@ public abstract class ArmorInventory extends Inventory {
 	public abstract void updateSlot(int i, ItemStack item, Entity entity);
 
 	@Override
-	public boolean canSet(int i, ItemStack item) {
-		if (!super.canSet(i, item)) {
+	public boolean canSet(int i, ItemStack item, Entity entity) {
+		if (!super.canSet(i, item, entity)) {
 			return false;
 		}
 		if (item != null) {
-			Material material = item.getMaterial();
-			switch (i) {
-				case BOOT_SLOT:
-					return material instanceof Boots;
-				case LEGGINGS_SLOT:
-					return material instanceof Leggings;
-				case CHEST_PLATE_SLOT:
-					return material instanceof Chestplate;
-				case HELMET_SLOT:
-					return material instanceof Helmet;
-				default:
-					return false;
-			}
+			return ((VanillaMaterial) item.getMaterial()).canEquip(entity, this, i);
 		}
 		return true;
 	}

--- a/src/main/java/org/spout/vanilla/api/material/VanillaMaterial.java
+++ b/src/main/java/org/spout/vanilla/api/material/VanillaMaterial.java
@@ -26,6 +26,8 @@
  */
 package org.spout.vanilla.api.material;
 
+import org.spout.api.entity.Entity;
+import org.spout.api.inventory.Inventory;
 import org.spout.api.material.source.MaterialSource;
 import org.spout.api.math.Vector2;
 import org.spout.api.render.RenderMaterial;
@@ -58,6 +60,15 @@ public interface VanillaMaterial extends MaterialSource {
 	 * @return minecraft data
 	 */
 	public short getMinecraftData(short data);
+
+	/**
+	 * Gets if the Material can be equipped in the given {@link org.spout.vanilla.api.inventory.entity.ArmorInventory} slot by the Entity.
+	 * @param entity that is attemptign to equip the item.
+	 * @param inventory the item is being equipped into.
+	 * @param slot the item is being equipped in.
+	 * @return true if the material can be equipped in the slot
+	 */
+	public boolean canEquip(Entity entity, Inventory inventory, int slot);
 
 	public RenderMaterial getRenderMaterial();
 

--- a/src/main/java/org/spout/vanilla/plugin/inventory/CraftingInventory.java
+++ b/src/main/java/org/spout/vanilla/plugin/inventory/CraftingInventory.java
@@ -31,6 +31,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.spout.api.Spout;
+import org.spout.api.entity.Entity;
 import org.spout.api.inventory.Inventory;
 import org.spout.api.inventory.InventoryViewer;
 import org.spout.api.inventory.ItemStack;
@@ -187,7 +188,7 @@ public class CraftingInventory extends Inventory {
 	}
 
 	@Override
-	public boolean canSet(int i, ItemStack item) {
-		return super.canSet(i, item) && i != outputSlot;
+	public boolean canSet(int i, ItemStack item, Entity entity) {
+		return super.canSet(i, item, entity) && i != outputSlot;
 	}
 }

--- a/src/main/java/org/spout/vanilla/plugin/inventory/block/AnvilInventory.java
+++ b/src/main/java/org/spout/vanilla/plugin/inventory/block/AnvilInventory.java
@@ -26,6 +26,7 @@
  */
 package org.spout.vanilla.plugin.inventory.block;
 
+import org.spout.api.entity.Entity;
 import org.spout.api.inventory.Inventory;
 import org.spout.api.inventory.ItemStack;
 
@@ -92,7 +93,7 @@ public class AnvilInventory extends Inventory {
 	}
 
 	@Override
-	public boolean canSet(int i, ItemStack item) {
-		return super.canSet(i, item) && i != OUTPUT_SLOT;
+	public boolean canSet(int i, ItemStack item, Entity entity) {
+		return super.canSet(i, item, entity) && i != OUTPUT_SLOT;
 	}
 }

--- a/src/main/java/org/spout/vanilla/plugin/inventory/block/BrewingStandInventory.java
+++ b/src/main/java/org/spout/vanilla/plugin/inventory/block/BrewingStandInventory.java
@@ -26,6 +26,7 @@
  */
 package org.spout.vanilla.plugin.inventory.block;
 
+import org.spout.api.entity.Entity;
 import org.spout.api.inventory.Inventory;
 import org.spout.api.inventory.ItemStack;
 
@@ -91,8 +92,8 @@ public class BrewingStandInventory extends Inventory {
 	}
 
 	@Override
-	public boolean canSet(int i, ItemStack item) {
-		if (!super.canSet(i, item)) {
+	public boolean canSet(int i, ItemStack item, Entity entity) {
+		if (!super.canSet(i, item, entity)) {
 			return false;
 		}
 

--- a/src/main/java/org/spout/vanilla/plugin/inventory/block/EnchantmentTableInventory.java
+++ b/src/main/java/org/spout/vanilla/plugin/inventory/block/EnchantmentTableInventory.java
@@ -26,6 +26,7 @@
  */
 package org.spout.vanilla.plugin.inventory.block;
 
+import org.spout.api.entity.Entity;
 import org.spout.api.inventory.Inventory;
 import org.spout.api.inventory.ItemStack;
 
@@ -98,7 +99,7 @@ public class EnchantmentTableInventory extends Inventory {
 	}
 
 	@Override
-	public boolean canSet(int i, ItemStack item) {
+	public boolean canSet(int i, ItemStack item, Entity entity) {
 		return item.getMaterial() instanceof VanillaItemMaterial && ((VanillaItemMaterial) item.getMaterial()).isEnchantable();
 	}
 }

--- a/src/main/java/org/spout/vanilla/plugin/inventory/block/FurnaceInventory.java
+++ b/src/main/java/org/spout/vanilla/plugin/inventory/block/FurnaceInventory.java
@@ -26,6 +26,7 @@
  */
 package org.spout.vanilla.plugin.inventory.block;
 
+import org.spout.api.entity.Entity;
 import org.spout.api.inventory.Inventory;
 import org.spout.api.inventory.ItemStack;
 
@@ -102,7 +103,7 @@ public class FurnaceInventory extends Inventory {
 	}
 
 	@Override
-	public boolean canSet(int i, ItemStack item) {
-		return super.canSet(i, item) && i != OUTPUT_SLOT;
+	public boolean canSet(int i, ItemStack item, Entity entity) {
+		return super.canSet(i, item, entity) && i != OUTPUT_SLOT;
 	}
 }

--- a/src/main/java/org/spout/vanilla/plugin/inventory/window/DefaultWindow.java
+++ b/src/main/java/org/spout/vanilla/plugin/inventory/window/DefaultWindow.java
@@ -104,7 +104,7 @@ public class DefaultWindow extends Window {
 			// Transferring to the armor slots
 			final ArmorInventory armor = inventory.getArmor();
 			for (int i = 0; i < armor.size(); i++) {
-				if (armor.get(i) == null && armor.canSet(i, stack)) {
+				if (armor.get(i) == null && armor.canSet(i, stack, getPlayer())) {
 					armor.set(i, ItemStack.cloneSpecial(stack));
 					from.set(slot, stack.setAmount(0));
 					return true;

--- a/src/main/java/org/spout/vanilla/plugin/inventory/window/Window.java
+++ b/src/main/java/org/spout/vanilla/plugin/inventory/window/Window.java
@@ -301,7 +301,7 @@ public abstract class Window implements InventoryViewer {
 					clicked = cursorItem.clone();
 					clicked.setAmount(1);
 					// Can it be set?
-					if (inventory.canSet(slot, clicked)) {
+					if (inventory.canSet(slot, clicked, owner)) {
 						inventory.set(slot, clicked);
 						// remove from cursor
 						cursorItem.setAmount(cursorItem.getAmount() - 1);
@@ -319,7 +319,7 @@ public abstract class Window implements InventoryViewer {
 						debug("[Window] Stacking");
 						// add one if can fit
 						clicked.setAmount(clicked.getAmount() + 1);
-						if (inventory.canSet(slot, clicked)) {
+						if (inventory.canSet(slot, clicked, owner)) {
 							inventory.set(slot, clicked);
 							cursorItem.setAmount(cursorItem.getAmount() - 1);
 							if (cursorItem.isEmpty()) {
@@ -339,7 +339,7 @@ public abstract class Window implements InventoryViewer {
 							}
 						}
 					}
-				} else if (inventory.canSet(slot, cursorItem)) {
+				} else if (inventory.canSet(slot, cursorItem, owner)) {
 					debug("[Window] Materials don't match. Swapping stacks.");
 					// materials don't match
 					// swap stacks
@@ -371,7 +371,7 @@ public abstract class Window implements InventoryViewer {
 					// put whole stack down
 					clicked = cursorItem.clone();
 					// Can it be set?
-					if (inventory.canSet(slot, clicked)) {
+					if (inventory.canSet(slot, clicked, owner)) {
 						inventory.set(slot, clicked);
 						cursorItem = null;
 						return true;
@@ -383,7 +383,7 @@ public abstract class Window implements InventoryViewer {
 				if (cursorItem.equalsIgnoreSize(clicked)) {
 					debug("[Window] Stacking");
 					//Try to set items
-					if (inventory.canSet(slot, clicked)) {
+					if (inventory.canSet(slot, clicked, owner)) {
 						clicked.stack(cursorItem);
 						inventory.set(slot, clicked);
 						if (cursorItem.isEmpty()) {
@@ -400,7 +400,7 @@ public abstract class Window implements InventoryViewer {
 						}
 					}
 					return true;
-				} else if (inventory.canSet(slot, cursorItem)) {
+				} else if (inventory.canSet(slot, cursorItem, owner)) {
 					debug("[Window] Materials don't match. Swapping stacks.");
 					// materials don't match
 					// swap stacks

--- a/src/main/java/org/spout/vanilla/plugin/material/VanillaBlockMaterial.java
+++ b/src/main/java/org/spout/vanilla/plugin/material/VanillaBlockMaterial.java
@@ -34,11 +34,13 @@ import java.util.Set;
 
 import org.spout.api.Spout;
 import org.spout.api.collision.CollisionStrategy;
+import org.spout.api.entity.Entity;
 import org.spout.api.entity.Player;
 import org.spout.api.event.Cause;
 import org.spout.api.geo.LoadOption;
 import org.spout.api.geo.cuboid.Block;
 import org.spout.api.geo.cuboid.Chunk;
+import org.spout.api.inventory.Inventory;
 import org.spout.api.inventory.ItemStack;
 import org.spout.api.material.BlockMaterial;
 import org.spout.api.material.block.BlockFace;
@@ -506,5 +508,10 @@ public abstract class VanillaBlockMaterial extends BlockMaterial implements Vani
 			top = top.getRelative(BlockFace.BOTTOM, LoadOption.NO_LOAD);
 		}
 		return rval;
+	}
+
+	@Override
+	public boolean canEquip(Entity entity, Inventory inventory, int slot) {
+		return false;
 	}
 }

--- a/src/main/java/org/spout/vanilla/plugin/material/block/solid/Pumpkin.java
+++ b/src/main/java/org/spout/vanilla/plugin/material/block/solid/Pumpkin.java
@@ -26,12 +26,16 @@
  */
 package org.spout.vanilla.plugin.material.block.solid;
 
+import org.spout.api.entity.Entity;
+import org.spout.api.entity.Player;
 import org.spout.api.event.Cause;
 import org.spout.api.geo.cuboid.Block;
+import org.spout.api.inventory.Inventory;
 import org.spout.api.material.block.BlockFace;
 import org.spout.api.material.block.BlockFaces;
 import org.spout.api.math.Vector3;
 
+import org.spout.vanilla.api.inventory.entity.ArmorInventory;
 import org.spout.vanilla.api.material.block.Directional;
 
 import org.spout.vanilla.plugin.data.tool.ToolType;
@@ -90,5 +94,13 @@ public class Pumpkin extends Solid implements Directional {
 	 */
 	public boolean isLantern() {
 		return lantern;
+	}
+
+	@Override
+	public boolean canEquip(Entity entity, Inventory inventory, int slot) {
+		if (!(inventory instanceof ArmorInventory)) {
+			return false;
+		}
+		return (!isLantern() || !(entity instanceof Player)) && slot == ArmorInventory.HELMET_SLOT;
 	}
 }

--- a/src/main/java/org/spout/vanilla/plugin/material/item/VanillaItemMaterial.java
+++ b/src/main/java/org/spout/vanilla/plugin/material/item/VanillaItemMaterial.java
@@ -26,6 +26,8 @@
  */
 package org.spout.vanilla.plugin.material.item;
 
+import org.spout.api.entity.Entity;
+import org.spout.api.inventory.Inventory;
 import org.spout.api.material.Material;
 import org.spout.api.math.Vector2;
 import org.spout.api.render.RenderMaterial;
@@ -90,6 +92,11 @@ public class VanillaItemMaterial extends Material implements VanillaMaterial {
 	@Override
 	public short getMinecraftData(short data) {
 		return data;
+	}
+
+	@Override
+	public boolean canEquip(Entity entity, Inventory inventory, int slot) {
+		return false;
 	}
 
 	@Override

--- a/src/main/java/org/spout/vanilla/plugin/material/item/armor/chain/ChainBoots.java
+++ b/src/main/java/org/spout/vanilla/plugin/material/item/armor/chain/ChainBoots.java
@@ -26,11 +26,19 @@
  */
 package org.spout.vanilla.plugin.material.item.armor.chain;
 
+import org.spout.api.entity.Entity;
+import org.spout.api.inventory.Inventory;
+import org.spout.vanilla.api.inventory.entity.ArmorInventory;
 import org.spout.vanilla.api.material.item.armor.Boots;
 
 public class ChainBoots extends ChainArmor implements Boots {
 	public ChainBoots(String name, int id, short durability) {
 		super(name, id, durability, null);
 		this.setBaseProtection(1);
+	}
+
+	@Override
+	public boolean canEquip(Entity entity, Inventory inventory, int slot) {
+		return inventory instanceof ArmorInventory && slot == ArmorInventory.BOOT_SLOT;
 	}
 }

--- a/src/main/java/org/spout/vanilla/plugin/material/item/armor/chain/ChainChestplate.java
+++ b/src/main/java/org/spout/vanilla/plugin/material/item/armor/chain/ChainChestplate.java
@@ -26,11 +26,19 @@
  */
 package org.spout.vanilla.plugin.material.item.armor.chain;
 
+import org.spout.api.entity.Entity;
+import org.spout.api.inventory.Inventory;
+import org.spout.vanilla.api.inventory.entity.ArmorInventory;
 import org.spout.vanilla.api.material.item.armor.Chestplate;
 
 public class ChainChestplate extends ChainArmor implements Chestplate {
 	public ChainChestplate(String name, int id, short durability) {
 		super(name, id, durability, null);
 		this.setBaseProtection(5);
+	}
+
+	@Override
+	public boolean canEquip(Entity entity, Inventory inventory, int slot) {
+		return inventory instanceof ArmorInventory && slot == ArmorInventory.CHEST_PLATE_SLOT;
 	}
 }

--- a/src/main/java/org/spout/vanilla/plugin/material/item/armor/chain/ChainHelmet.java
+++ b/src/main/java/org/spout/vanilla/plugin/material/item/armor/chain/ChainHelmet.java
@@ -26,11 +26,19 @@
  */
 package org.spout.vanilla.plugin.material.item.armor.chain;
 
+import org.spout.api.entity.Entity;
+import org.spout.api.inventory.Inventory;
+import org.spout.vanilla.api.inventory.entity.ArmorInventory;
 import org.spout.vanilla.api.material.item.armor.Helmet;
 
 public class ChainHelmet extends ChainArmor implements Helmet {
 	public ChainHelmet(String name, int id, short durability) {
 		super(name, id, durability, null);
 		this.setBaseProtection(2);
+	}
+
+	@Override
+	public boolean canEquip(Entity entity, Inventory inventory, int slot) {
+		return inventory instanceof ArmorInventory && slot == ArmorInventory.HELMET_SLOT;
 	}
 }

--- a/src/main/java/org/spout/vanilla/plugin/material/item/armor/chain/ChainLeggings.java
+++ b/src/main/java/org/spout/vanilla/plugin/material/item/armor/chain/ChainLeggings.java
@@ -26,11 +26,19 @@
  */
 package org.spout.vanilla.plugin.material.item.armor.chain;
 
+import org.spout.api.entity.Entity;
+import org.spout.api.inventory.Inventory;
+import org.spout.vanilla.api.inventory.entity.ArmorInventory;
 import org.spout.vanilla.api.material.item.armor.Leggings;
 
 public class ChainLeggings extends ChainArmor implements Leggings {
 	public ChainLeggings(String name, int id, short durability) {
 		super(name, id, durability, null);
 		this.setBaseProtection(4);
+	}
+
+	@Override
+	public boolean canEquip(Entity entity, Inventory inventory, int slot) {
+		return inventory instanceof ArmorInventory && slot == ArmorInventory.LEGGINGS_SLOT;
 	}
 }

--- a/src/main/java/org/spout/vanilla/plugin/material/item/armor/diamond/DiamondBoots.java
+++ b/src/main/java/org/spout/vanilla/plugin/material/item/armor/diamond/DiamondBoots.java
@@ -26,11 +26,19 @@
  */
 package org.spout.vanilla.plugin.material.item.armor.diamond;
 
+import org.spout.api.entity.Entity;
+import org.spout.api.inventory.Inventory;
+import org.spout.vanilla.api.inventory.entity.ArmorInventory;
 import org.spout.vanilla.api.material.item.armor.Boots;
 
 public class DiamondBoots extends DiamondArmor implements Boots {
 	public DiamondBoots(String name, int id, short durability) {
 		super(name, id, durability, null);
 		this.setBaseProtection(3);
+	}
+
+	@Override
+	public boolean canEquip(Entity entity, Inventory inventory, int slot) {
+		return inventory instanceof ArmorInventory && slot == ArmorInventory.BOOT_SLOT;
 	}
 }

--- a/src/main/java/org/spout/vanilla/plugin/material/item/armor/diamond/DiamondChestplate.java
+++ b/src/main/java/org/spout/vanilla/plugin/material/item/armor/diamond/DiamondChestplate.java
@@ -26,11 +26,19 @@
  */
 package org.spout.vanilla.plugin.material.item.armor.diamond;
 
+import org.spout.api.entity.Entity;
+import org.spout.api.inventory.Inventory;
+import org.spout.vanilla.api.inventory.entity.ArmorInventory;
 import org.spout.vanilla.api.material.item.armor.Chestplate;
 
 public class DiamondChestplate extends DiamondArmor implements Chestplate {
 	public DiamondChestplate(String name, int id, short durability) {
 		super(name, id, durability, null);
 		this.setBaseProtection(8);
+	}
+
+	@Override
+	public boolean canEquip(Entity entity, Inventory inventory, int slot) {
+		return inventory instanceof ArmorInventory && slot == ArmorInventory.CHEST_PLATE_SLOT;
 	}
 }

--- a/src/main/java/org/spout/vanilla/plugin/material/item/armor/diamond/DiamondHelmet.java
+++ b/src/main/java/org/spout/vanilla/plugin/material/item/armor/diamond/DiamondHelmet.java
@@ -26,11 +26,19 @@
  */
 package org.spout.vanilla.plugin.material.item.armor.diamond;
 
+import org.spout.api.entity.Entity;
+import org.spout.api.inventory.Inventory;
+import org.spout.vanilla.api.inventory.entity.ArmorInventory;
 import org.spout.vanilla.api.material.item.armor.Helmet;
 
 public class DiamondHelmet extends DiamondArmor implements Helmet {
 	public DiamondHelmet(String name, int id, short durability) {
 		super(name, id, durability, null);
 		this.setBaseProtection(3);
+	}
+
+	@Override
+	public boolean canEquip(Entity entity, Inventory inventory, int slot) {
+		return inventory instanceof ArmorInventory && slot == ArmorInventory.HELMET_SLOT;
 	}
 }

--- a/src/main/java/org/spout/vanilla/plugin/material/item/armor/diamond/DiamondLeggings.java
+++ b/src/main/java/org/spout/vanilla/plugin/material/item/armor/diamond/DiamondLeggings.java
@@ -26,11 +26,19 @@
  */
 package org.spout.vanilla.plugin.material.item.armor.diamond;
 
+import org.spout.api.entity.Entity;
+import org.spout.api.inventory.Inventory;
+import org.spout.vanilla.api.inventory.entity.ArmorInventory;
 import org.spout.vanilla.api.material.item.armor.Leggings;
 
 public class DiamondLeggings extends DiamondArmor implements Leggings {
 	public DiamondLeggings(String name, int id, short durability) {
 		super(name, id, durability, null);
 		this.setBaseProtection(6);
+	}
+
+	@Override
+	public boolean canEquip(Entity entity, Inventory inventory, int slot) {
+		return inventory instanceof ArmorInventory && slot == ArmorInventory.LEGGINGS_SLOT;
 	}
 }

--- a/src/main/java/org/spout/vanilla/plugin/material/item/armor/gold/GoldBoots.java
+++ b/src/main/java/org/spout/vanilla/plugin/material/item/armor/gold/GoldBoots.java
@@ -26,11 +26,19 @@
  */
 package org.spout.vanilla.plugin.material.item.armor.gold;
 
+import org.spout.api.entity.Entity;
+import org.spout.api.inventory.Inventory;
+import org.spout.vanilla.api.inventory.entity.ArmorInventory;
 import org.spout.vanilla.api.material.item.armor.Boots;
 
 public class GoldBoots extends GoldArmor implements Boots {
 	public GoldBoots(String name, int id, short durability) {
 		super(name, id, durability, null);
 		this.setBaseProtection(1);
+	}
+
+	@Override
+	public boolean canEquip(Entity entity, Inventory inventory, int slot) {
+		return inventory instanceof ArmorInventory && slot == ArmorInventory.BOOT_SLOT;
 	}
 }

--- a/src/main/java/org/spout/vanilla/plugin/material/item/armor/gold/GoldChestplate.java
+++ b/src/main/java/org/spout/vanilla/plugin/material/item/armor/gold/GoldChestplate.java
@@ -26,11 +26,19 @@
  */
 package org.spout.vanilla.plugin.material.item.armor.gold;
 
+import org.spout.api.entity.Entity;
+import org.spout.api.inventory.Inventory;
+import org.spout.vanilla.api.inventory.entity.ArmorInventory;
 import org.spout.vanilla.api.material.item.armor.Chestplate;
 
 public class GoldChestplate extends GoldArmor implements Chestplate {
 	public GoldChestplate(String name, int id, short durability) {
 		super(name, id, durability, null);
 		this.setBaseProtection(5);
+	}
+
+	@Override
+	public boolean canEquip(Entity entity, Inventory inventory, int slot) {
+		return inventory instanceof ArmorInventory && slot == ArmorInventory.CHEST_PLATE_SLOT;
 	}
 }

--- a/src/main/java/org/spout/vanilla/plugin/material/item/armor/gold/GoldHelmet.java
+++ b/src/main/java/org/spout/vanilla/plugin/material/item/armor/gold/GoldHelmet.java
@@ -26,11 +26,19 @@
  */
 package org.spout.vanilla.plugin.material.item.armor.gold;
 
+import org.spout.api.entity.Entity;
+import org.spout.api.inventory.Inventory;
+import org.spout.vanilla.api.inventory.entity.ArmorInventory;
 import org.spout.vanilla.api.material.item.armor.Helmet;
 
 public class GoldHelmet extends GoldArmor implements Helmet {
 	public GoldHelmet(String name, int id, short durability) {
 		super(name, id, durability, null);
 		this.setBaseProtection(2);
+	}
+
+	@Override
+	public boolean canEquip(Entity entity, Inventory inventory, int slot) {
+		return inventory instanceof ArmorInventory && slot == ArmorInventory.HELMET_SLOT;
 	}
 }

--- a/src/main/java/org/spout/vanilla/plugin/material/item/armor/gold/GoldLeggings.java
+++ b/src/main/java/org/spout/vanilla/plugin/material/item/armor/gold/GoldLeggings.java
@@ -26,11 +26,19 @@
  */
 package org.spout.vanilla.plugin.material.item.armor.gold;
 
+import org.spout.api.entity.Entity;
+import org.spout.api.inventory.Inventory;
+import org.spout.vanilla.api.inventory.entity.ArmorInventory;
 import org.spout.vanilla.api.material.item.armor.Leggings;
 
 public class GoldLeggings extends GoldArmor implements Leggings {
 	public GoldLeggings(String name, int id, short durability) {
 		super(name, id, durability, null);
 		this.setBaseProtection(3);
+	}
+
+	@Override
+	public boolean canEquip(Entity entity, Inventory inventory, int slot) {
+		return inventory instanceof ArmorInventory && slot == ArmorInventory.LEGGINGS_SLOT;
 	}
 }

--- a/src/main/java/org/spout/vanilla/plugin/material/item/armor/iron/IronBoots.java
+++ b/src/main/java/org/spout/vanilla/plugin/material/item/armor/iron/IronBoots.java
@@ -26,11 +26,19 @@
  */
 package org.spout.vanilla.plugin.material.item.armor.iron;
 
+import org.spout.api.entity.Entity;
+import org.spout.api.inventory.Inventory;
+import org.spout.vanilla.api.inventory.entity.ArmorInventory;
 import org.spout.vanilla.api.material.item.armor.Boots;
 
 public class IronBoots extends IronArmor implements Boots {
 	public IronBoots(String name, int id, short durability) {
 		super(name, id, durability, null);
 		this.setBaseProtection(2);
+	}
+
+	@Override
+	public boolean canEquip(Entity entity, Inventory inventory, int slot) {
+		return inventory instanceof ArmorInventory && slot == ArmorInventory.BOOT_SLOT;
 	}
 }

--- a/src/main/java/org/spout/vanilla/plugin/material/item/armor/iron/IronChestplate.java
+++ b/src/main/java/org/spout/vanilla/plugin/material/item/armor/iron/IronChestplate.java
@@ -26,11 +26,19 @@
  */
 package org.spout.vanilla.plugin.material.item.armor.iron;
 
+import org.spout.api.entity.Entity;
+import org.spout.api.inventory.Inventory;
+import org.spout.vanilla.api.inventory.entity.ArmorInventory;
 import org.spout.vanilla.api.material.item.armor.Chestplate;
 
 public class IronChestplate extends IronArmor implements Chestplate {
 	public IronChestplate(String name, int id, short durability) {
 		super(name, id, durability, null);
 		this.setBaseProtection(6);
+	}
+
+	@Override
+	public boolean canEquip(Entity entity, Inventory inventory, int slot) {
+		return inventory instanceof ArmorInventory && slot == ArmorInventory.CHEST_PLATE_SLOT;
 	}
 }

--- a/src/main/java/org/spout/vanilla/plugin/material/item/armor/iron/IronHelmet.java
+++ b/src/main/java/org/spout/vanilla/plugin/material/item/armor/iron/IronHelmet.java
@@ -26,11 +26,19 @@
  */
 package org.spout.vanilla.plugin.material.item.armor.iron;
 
+import org.spout.api.entity.Entity;
+import org.spout.api.inventory.Inventory;
+import org.spout.vanilla.api.inventory.entity.ArmorInventory;
 import org.spout.vanilla.api.material.item.armor.Helmet;
 
 public class IronHelmet extends IronArmor implements Helmet {
 	public IronHelmet(String name, int id, short durability) {
 		super(name, id, durability, null);
 		this.setBaseProtection(2);
+	}
+
+	@Override
+	public boolean canEquip(Entity entity, Inventory inventory, int slot) {
+		return inventory instanceof ArmorInventory && slot == ArmorInventory.HELMET_SLOT;
 	}
 }

--- a/src/main/java/org/spout/vanilla/plugin/material/item/armor/iron/IronLeggings.java
+++ b/src/main/java/org/spout/vanilla/plugin/material/item/armor/iron/IronLeggings.java
@@ -26,11 +26,19 @@
  */
 package org.spout.vanilla.plugin.material.item.armor.iron;
 
+import org.spout.api.entity.Entity;
+import org.spout.api.inventory.Inventory;
+import org.spout.vanilla.api.inventory.entity.ArmorInventory;
 import org.spout.vanilla.api.material.item.armor.Leggings;
 
 public class IronLeggings extends IronArmor implements Leggings {
 	public IronLeggings(String name, int id, short durability) {
 		super(name, id, durability, null);
 		this.setBaseProtection(5);
+	}
+
+	@Override
+	public boolean canEquip(Entity entity, Inventory inventory, int slot) {
+		return inventory instanceof ArmorInventory && slot == ArmorInventory.LEGGINGS_SLOT;
 	}
 }

--- a/src/main/java/org/spout/vanilla/plugin/material/item/armor/leather/LeatherBoots.java
+++ b/src/main/java/org/spout/vanilla/plugin/material/item/armor/leather/LeatherBoots.java
@@ -26,11 +26,19 @@
  */
 package org.spout.vanilla.plugin.material.item.armor.leather;
 
+import org.spout.api.entity.Entity;
+import org.spout.api.inventory.Inventory;
+import org.spout.vanilla.api.inventory.entity.ArmorInventory;
 import org.spout.vanilla.api.material.item.armor.Boots;
 
 public class LeatherBoots extends LeatherArmor implements Boots {
 	public LeatherBoots(String name, int id, short durability) {
 		super(name, id, durability, null);
 		this.setBaseProtection(1);
+	}
+
+	@Override
+	public boolean canEquip(Entity entity, Inventory inventory, int slot) {
+		return inventory instanceof ArmorInventory && slot == ArmorInventory.BOOT_SLOT;
 	}
 }

--- a/src/main/java/org/spout/vanilla/plugin/material/item/armor/leather/LeatherCap.java
+++ b/src/main/java/org/spout/vanilla/plugin/material/item/armor/leather/LeatherCap.java
@@ -26,8 +26,11 @@
  */
 package org.spout.vanilla.plugin.material.item.armor.leather;
 
+import org.spout.api.entity.Entity;
+import org.spout.api.inventory.Inventory;
 import org.spout.api.math.Vector2;
 
+import org.spout.vanilla.api.inventory.entity.ArmorInventory;
 import org.spout.vanilla.api.material.item.armor.Helmet;
 
 public class LeatherCap extends LeatherArmor implements Helmet {
@@ -36,5 +39,10 @@ public class LeatherCap extends LeatherArmor implements Helmet {
 	public LeatherCap(String name, int id, short durability) {
 		super(name, id, durability, POSITION);
 		this.setBaseProtection(1);
+	}
+
+	@Override
+	public boolean canEquip(Entity entity, Inventory inventory, int slot) {
+		return inventory instanceof ArmorInventory && slot == ArmorInventory.HELMET_SLOT;
 	}
 }

--- a/src/main/java/org/spout/vanilla/plugin/material/item/armor/leather/LeatherPants.java
+++ b/src/main/java/org/spout/vanilla/plugin/material/item/armor/leather/LeatherPants.java
@@ -26,11 +26,19 @@
  */
 package org.spout.vanilla.plugin.material.item.armor.leather;
 
+import org.spout.api.entity.Entity;
+import org.spout.api.inventory.Inventory;
+import org.spout.vanilla.api.inventory.entity.ArmorInventory;
 import org.spout.vanilla.api.material.item.armor.Leggings;
 
 public class LeatherPants extends LeatherArmor implements Leggings {
 	public LeatherPants(String name, int id, short durability) {
 		super(name, id, durability, null);
 		this.setBaseProtection(2);
+	}
+
+	@Override
+	public boolean canEquip(Entity entity, Inventory inventory, int slot) {
+		return inventory instanceof ArmorInventory && slot == ArmorInventory.LEGGINGS_SLOT;
 	}
 }

--- a/src/main/java/org/spout/vanilla/plugin/material/item/armor/leather/LeatherTunic.java
+++ b/src/main/java/org/spout/vanilla/plugin/material/item/armor/leather/LeatherTunic.java
@@ -26,11 +26,19 @@
  */
 package org.spout.vanilla.plugin.material.item.armor.leather;
 
+import org.spout.api.entity.Entity;
+import org.spout.api.inventory.Inventory;
+import org.spout.vanilla.api.inventory.entity.ArmorInventory;
 import org.spout.vanilla.api.material.item.armor.Chestplate;
 
 public class LeatherTunic extends LeatherArmor implements Chestplate {
 	public LeatherTunic(String name, int id, short durability) {
 		super(name, id, durability, null);
 		this.setBaseProtection(3);
+	}
+
+	@Override
+	public boolean canEquip(Entity entity, Inventory inventory, int slot) {
+		return inventory instanceof ArmorInventory && slot == ArmorInventory.CHEST_PLATE_SLOT;
 	}
 }

--- a/src/main/java/org/spout/vanilla/plugin/material/item/misc/Skull.java
+++ b/src/main/java/org/spout/vanilla/plugin/material/item/misc/Skull.java
@@ -26,6 +26,9 @@
  */
 package org.spout.vanilla.plugin.material.item.misc;
 
+import org.spout.api.entity.Entity;
+import org.spout.api.inventory.Inventory;
+import org.spout.vanilla.api.inventory.entity.ArmorInventory;
 import org.spout.vanilla.plugin.material.block.component.SkullBlock;
 import org.spout.vanilla.plugin.material.item.BlockItem;
 
@@ -47,5 +50,10 @@ public class Skull extends BlockItem {
 	@Override
 	public Skull getParentMaterial() {
 		return (Skull) super.getParentMaterial();
+	}
+
+	@Override
+	public boolean canEquip(Entity entity, Inventory inventory, int slot) {
+		return inventory instanceof ArmorInventory && slot == ArmorInventory.HELMET_SLOT;
 	}
 }


### PR DESCRIPTION
No longer use Inventory to control if a material is wearable in a specific inventory slot.
All materials default to not being equipable, now override canEquip.
Fixes Skulls & Pumpkins not being equipable in Helm slot.

Signed-off-by: Nick Minkler sleaker@gmail.com
