### PR TITLE
More Inventory work

### DIFF
--- a/src/main/java/org/spout/vanilla/api/inventory/entity/ArmorInventory.java
+++ b/src/main/java/org/spout/vanilla/api/inventory/entity/ArmorInventory.java
@@ -26,6 +26,8 @@
  */
 package org.spout.vanilla.api.inventory.entity;
 
+import org.spout.vanilla.plugin.material.block.solid.Pumpkin;
+
 import org.spout.api.entity.Entity;
 import org.spout.api.inventory.Inventory;
 import org.spout.api.inventory.ItemStack;
@@ -67,13 +69,10 @@ public abstract class ArmorInventory extends Inventory {
 	public abstract void updateSlot(int i, ItemStack item, Entity entity);
 
 	@Override
-	public boolean canSet(int i, ItemStack item) {
-		if (!super.canSet(i, item)) {
-			return false;
-		}
+	public boolean canSet(int slot, ItemStack item) {
 		if (item != null) {
 			Material material = item.getMaterial();
-			switch (i) {
+			switch (slot) {
 				case BOOT_SLOT:
 					return material instanceof Boots;
 				case LEGGINGS_SLOT:
@@ -81,7 +80,7 @@ public abstract class ArmorInventory extends Inventory {
 				case CHEST_PLATE_SLOT:
 					return material instanceof Chestplate;
 				case HELMET_SLOT:
-					return material instanceof Helmet;
+					return material instanceof Helmet || material instanceof Pumpkin;
 				default:
 					return false;
 			}

--- a/src/main/java/org/spout/vanilla/plugin/component/inventory/PlayerInventory.java
+++ b/src/main/java/org/spout/vanilla/plugin/component/inventory/PlayerInventory.java
@@ -40,6 +40,7 @@ import org.spout.vanilla.plugin.data.VanillaData;
  * Represents a players inventory
  */
 public class PlayerInventory extends PlayerInventoryComponent {
+
 	@Override
 	public QuickbarInventory getQuickbar() {
 		return getData().get(VanillaData.QUICKBAR_INVENTORY);
@@ -52,7 +53,7 @@ public class PlayerInventory extends PlayerInventoryComponent {
 
 	@Override
 	public ArmorInventory getArmor() {
-		return getData().get(VanillaData.ARMOR_INVENTORY);
+		return getData().get(VanillaData.PLAYER_ARMOR_INVENTORY);
 	}
 
 	@Override

--- a/src/main/java/org/spout/vanilla/plugin/data/VanillaData.java
+++ b/src/main/java/org/spout/vanilla/plugin/data/VanillaData.java
@@ -42,6 +42,8 @@ import org.spout.vanilla.api.data.GameMode;
 import org.spout.vanilla.api.data.PaintingType;
 import org.spout.vanilla.api.data.Weather;
 import org.spout.vanilla.api.data.WorldType;
+
+import org.spout.vanilla.plugin.inventory.player.PlayerArmorInventory;
 import org.spout.vanilla.plugin.inventory.player.PlayerCraftingInventory;
 
 import org.spout.vanilla.plugin.inventory.block.BrewingStandInventory;
@@ -128,6 +130,7 @@ public class VanillaData {
 	public static final DefaultedKey<PlayerMainInventory> MAIN_INVENTORY = new DefaultedKeyFactory<PlayerMainInventory>("main", PlayerMainInventory.class);
 	public static final DefaultedKey<PlayerCraftingInventory> CRAFTING_INVENTORY = new DefaultedKeyFactory<PlayerCraftingInventory>("crafting", PlayerCraftingInventory.class);
 	public static final DefaultedKey<EntityArmorInventory> ARMOR_INVENTORY = new DefaultedKeyFactory<EntityArmorInventory>("armor", EntityArmorInventory.class);
+	public static final DefaultedKey<PlayerArmorInventory> PLAYER_ARMOR_INVENTORY = new DefaultedKeyFactory<PlayerArmorInventory>("armor", PlayerArmorInventory.class);
 	public static final DefaultedKey<PlayerQuickbar> QUICKBAR_INVENTORY = new DefaultedKeyFactory<PlayerQuickbar>("quickbar", PlayerQuickbar.class);
 	public static final DefaultedKey<ChestInventory> ENDER_CHEST_INVENTORY = new DefaultedKeyFactory<ChestInventory>("ender_chest_inventory", ChestInventory.class);
 	public static final DefaultedKey<EntityQuickbarInventory> ENTITY_HELD_INVENTORY = new DefaultedKeyFactory<EntityQuickbarInventory>("held", EntityQuickbarInventory.class);

--- a/src/main/java/org/spout/vanilla/plugin/inventory/player/PlayerArmorInventory.java
+++ b/src/main/java/org/spout/vanilla/plugin/inventory/player/PlayerArmorInventory.java
@@ -24,30 +24,38 @@
  * License and see <http://spout.in/licensev1> for the full license, including
  * the MIT license.
  */
-package org.spout.vanilla.plugin.material.item.misc;
+package org.spout.vanilla.plugin.inventory.player;
 
-import org.spout.vanilla.plugin.material.block.component.SkullBlock;
-import org.spout.vanilla.plugin.material.item.BlockItem;
+import org.spout.vanilla.plugin.inventory.entity.EntityArmorInventory;
+import org.spout.vanilla.plugin.material.block.solid.Pumpkin;
 
+import org.spout.api.inventory.ItemStack;
+import org.spout.api.material.Material;
+
+import org.spout.vanilla.api.material.item.armor.Boots;
+import org.spout.vanilla.api.material.item.armor.Chestplate;
 import org.spout.vanilla.api.material.item.armor.Helmet;
+import org.spout.vanilla.api.material.item.armor.Leggings;
 
-public class Skull extends BlockItem implements Helmet {
-	public static final Skull SKELETON_SKULL = new Skull("Skeleton Skull");
-	public static final Skull WITHER_SKELETON_SKULL = new Skull("Wither Skeleton Skull", 1, SkullBlock.WITHER_SKELETON_SKULL);
-	public static final Skull ZOMBIE_HEAD = new Skull("Zombie Head", 2, SkullBlock.ZOMBIE_HEAD);
-	public static final Skull HEAD = new Skull("Head", 3, SkullBlock.HEAD);
-	public static final Skull CREEPER_HEAD = new Skull("Creeper Head", 4, SkullBlock.CREEPER_HEAD);
-
-	private Skull(String name) {
-		super((short) 0x7, name, 397, SkullBlock.SKELETON_SKULL, null);
-	}
-
-	private Skull(String name, int data, SkullBlock placed) {
-		super(name, 397, data, SKELETON_SKULL, placed, null);
-	}
+public class PlayerArmorInventory extends EntityArmorInventory {
 
 	@Override
-	public Skull getParentMaterial() {
-		return (Skull) super.getParentMaterial();
+	public boolean canSet(int slot, ItemStack item) {
+		if (item != null) {
+			Material material = item.getMaterial();
+			switch (slot) {
+				case BOOT_SLOT:
+					return material instanceof Boots;
+				case LEGGINGS_SLOT:
+					return material instanceof Leggings;
+				case CHEST_PLATE_SLOT:
+					return material instanceof Chestplate;
+				case HELMET_SLOT:
+					return material instanceof Helmet || (material instanceof Pumpkin && !((Pumpkin) material).isLantern());
+				default:
+					return false;
+			}
+		}
+		return true;
 	}
 }


### PR DESCRIPTION
Fix Skulls not being wearable. Seperate PlayerArmorInventory out from EntityArmorInventory, allows us to define alternate restrictions.

Signed-off-by: Nick Minkler sleaker@gmail.com
