### PR TITLE
Monsters equipping items

### DIFF
--- a/src/main/java/org/spout/vanilla/plugin/VanillaListener.java
+++ b/src/main/java/org/spout/vanilla/plugin/VanillaListener.java
@@ -53,7 +53,7 @@ import org.spout.vanilla.plugin.component.living.neutral.Human;
 import org.spout.vanilla.plugin.component.misc.HealthComponent;
 import org.spout.vanilla.plugin.component.misc.HungerComponent;
 import org.spout.vanilla.plugin.component.misc.LevelComponent;
-import org.spout.vanilla.plugin.component.misc.PickupItemComponent;
+import org.spout.vanilla.plugin.component.misc.PlayerPickupItemComponent;
 import org.spout.vanilla.plugin.component.misc.SleepComponent;
 import org.spout.vanilla.plugin.component.player.HUDComponent;
 import org.spout.vanilla.plugin.component.player.PingComponent;
@@ -92,7 +92,7 @@ public class VanillaListener implements Listener {
 		player.add(WindowHolder.class);
 		player.add(PlayerListComponent.class);
 		player.add(PingComponent.class);
-		player.add(PickupItemComponent.class);
+		player.add(PlayerPickupItemComponent.class);
 		player.add(SleepComponent.class);
 		player.add(HungerComponent.class);
 		player.add(LevelComponent.class);

--- a/src/main/java/org/spout/vanilla/plugin/component/living/hostile/Skeleton.java
+++ b/src/main/java/org/spout/vanilla/plugin/component/living/hostile/Skeleton.java
@@ -39,6 +39,7 @@ import org.spout.vanilla.plugin.VanillaPlugin;
 import org.spout.vanilla.plugin.component.inventory.VanillaEntityInventory;
 import org.spout.vanilla.plugin.component.living.Living;
 import org.spout.vanilla.plugin.component.misc.DropComponent;
+import org.spout.vanilla.plugin.component.misc.EntityPickupItemComponent;
 import org.spout.vanilla.plugin.component.misc.HealthComponent;
 import org.spout.vanilla.plugin.material.VanillaMaterials;
 import org.spout.vanilla.plugin.protocol.entity.creature.SkeletonEntityProtocol;
@@ -54,6 +55,7 @@ public class Skeleton extends Living implements Hostile {
 		SceneComponent scene = getOwner().getScene();
 		DropComponent dropComponent = getOwner().add(DropComponent.class);
 		getOwner().add(VanillaEntityInventory.class);
+		getOwner().add(EntityPickupItemComponent.class);
 		Random random = getRandom();
 		dropComponent.addDrop(new ItemStack(VanillaMaterials.ARROW, random.nextInt(2)));
 		dropComponent.addDrop(new ItemStack(VanillaMaterials.BONE, random.nextInt(2)));

--- a/src/main/java/org/spout/vanilla/plugin/component/living/hostile/Zombie.java
+++ b/src/main/java/org/spout/vanilla/plugin/component/living/hostile/Zombie.java
@@ -45,6 +45,7 @@ import org.spout.vanilla.plugin.component.living.Living;
 import org.spout.vanilla.plugin.component.living.neutral.Human;
 import org.spout.vanilla.plugin.component.misc.DamageComponent;
 import org.spout.vanilla.plugin.component.misc.DropComponent;
+import org.spout.vanilla.plugin.component.misc.EntityPickupItemComponent;
 import org.spout.vanilla.plugin.component.misc.HealthComponent;
 import org.spout.vanilla.plugin.data.VanillaData;
 import org.spout.vanilla.plugin.material.VanillaMaterials;
@@ -59,6 +60,8 @@ public class Zombie extends Living implements Hostile {
 		super.onAttached();
 		getOwner().getNetwork().setEntityProtocol(VanillaPlugin.VANILLA_PROTOCOL_ID, new ZombieEntityProtocol());
 		getOwner().add(DropComponent.class).addDrop(new ItemStack(VanillaMaterials.ROTTEN_FLESH, getRandom().nextInt(2))).addXpDrop((short) 5);
+		getOwner().add(VanillaEntityInventory.class);
+		getOwner().add(EntityPickupItemComponent.class);
 		SceneComponent scene = getOwner().getScene();
 		scene.setShape(5f, new BoxShape(1F, 2F, 1F));
 		scene.setFriction(1f);

--- a/src/main/java/org/spout/vanilla/plugin/component/living/neutral/Human.java
+++ b/src/main/java/org/spout/vanilla/plugin/component/living/neutral/Human.java
@@ -56,7 +56,7 @@ import org.spout.vanilla.plugin.component.living.Living;
 import org.spout.vanilla.plugin.component.misc.DiggingComponent;
 import org.spout.vanilla.plugin.component.misc.HeadComponent;
 import org.spout.vanilla.plugin.component.misc.HealthComponent;
-import org.spout.vanilla.plugin.component.misc.PickupItemComponent;
+import org.spout.vanilla.plugin.component.misc.PlayerPickupItemComponent;
 import org.spout.vanilla.plugin.component.substance.object.Item;
 import org.spout.vanilla.plugin.configuration.VanillaConfiguration;
 import org.spout.vanilla.plugin.configuration.WorldConfigurationNode;
@@ -77,7 +77,7 @@ public class Human extends Living {
 	public void onAttached() {
 		super.onAttached();
 		Entity holder = getOwner();
-		holder.add(PickupItemComponent.class);
+		holder.add(PlayerPickupItemComponent.class);
 		holder.add(DiggingComponent.class);
 		holder.getNetwork().setEntityProtocol(VanillaPlugin.VANILLA_PROTOCOL_ID, new HumanEntityProtocol());
 		//Add height offset if loading from disk

--- a/src/main/java/org/spout/vanilla/plugin/component/living/neutral/PigZombie.java
+++ b/src/main/java/org/spout/vanilla/plugin/component/living/neutral/PigZombie.java
@@ -33,6 +33,7 @@ import org.spout.vanilla.plugin.VanillaPlugin;
 import org.spout.vanilla.plugin.component.inventory.VanillaEntityInventory;
 import org.spout.vanilla.plugin.component.living.Living;
 import org.spout.vanilla.plugin.component.misc.DamageComponent;
+import org.spout.vanilla.plugin.component.misc.EntityPickupItemComponent;
 import org.spout.vanilla.plugin.component.misc.HealthComponent;
 import org.spout.vanilla.plugin.protocol.entity.creature.CreatureProtocol;
 import org.spout.vanilla.plugin.protocol.entity.creature.CreatureType;
@@ -46,7 +47,7 @@ public class PigZombie extends Living implements Neutral {
 		super.onAttached();
 		getOwner().getNetwork().setEntityProtocol(VanillaPlugin.VANILLA_PROTOCOL_ID, new CreatureProtocol(CreatureType.PIG_ZOMBIE));
 		getOwner().add(VanillaEntityInventory.class);
-
+		getOwner().add(EntityPickupItemComponent.class);
 		if (getAttachedCount() == 1) {
 			getOwner().add(HealthComponent.class).setSpawnHealth(20);
 		}

--- a/src/main/java/org/spout/vanilla/plugin/component/misc/EntityPickupItemComponent.java
+++ b/src/main/java/org/spout/vanilla/plugin/component/misc/EntityPickupItemComponent.java
@@ -1,0 +1,133 @@
+/*
+ * This file is part of Vanilla.
+ *
+ * Copyright (c) 2011-2012, Spout LLC <http://www.spout.org/>
+ * Vanilla is licensed under the Spout License Version 1.
+ *
+ * Vanilla is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * In addition, 180 days after any changes are published, you can use the
+ * software, incorporating those changes, under the terms of the MIT license,
+ * as described in the Spout License Version 1.
+ *
+ * Vanilla is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License,
+ * the MIT license and the Spout License Version 1 along with this program.
+ * If not, see <http://www.gnu.org/licenses/> for the GNU Lesser General Public
+ * License and see <http://spout.in/licensev1> for the full license, including
+ * the MIT license.
+ */
+package org.spout.vanilla.plugin.component.misc;
+
+import java.util.List;
+import org.spout.vanilla.plugin.component.inventory.PlayerInventory;
+import org.spout.vanilla.plugin.component.inventory.VanillaEntityInventory;
+import org.spout.vanilla.plugin.component.substance.object.Item;
+import org.spout.vanilla.plugin.configuration.VanillaConfiguration;
+import org.spout.vanilla.plugin.inventory.entity.EntityArmorInventory;
+import org.spout.vanilla.plugin.inventory.entity.EntityQuickbarInventory;
+import org.spout.vanilla.plugin.material.item.VanillaItemMaterial;
+import org.spout.vanilla.plugin.material.item.armor.Armor;
+import org.spout.vanilla.plugin.material.item.tool.Tool;
+
+import org.spout.api.component.type.EntityComponent;
+import org.spout.api.entity.Entity;
+import org.spout.api.inventory.ItemStack;
+import org.spout.api.material.Material;
+import org.spout.api.math.Vector3;
+
+import org.spout.vanilla.api.event.entity.EntityCollectItemEvent;
+import org.spout.vanilla.api.inventory.entity.ArmorInventory;
+
+/**
+ * Component that adds a detector to resources.entities to scan for and pickup items.
+ */
+public class EntityPickupItemComponent extends EntityComponent {
+	private final int DISTANCE = VanillaConfiguration.ITEM_PICKUP_RANGE.getInt();
+	private List<Entity> nearbyEntities;
+	private final int WAIT_RESET = 30;
+	private int wait = 0;
+
+	@Override
+	public boolean canTick() {
+		HealthComponent healthComponent = getOwner().get(HealthComponent.class);
+		if (healthComponent != null) {
+			if (!healthComponent.isDead() && wait != 0) {
+				wait--;
+				return false;
+			}
+			if (healthComponent.isDead()) {
+				wait = WAIT_RESET;
+				return false;
+			}
+		}
+		nearbyEntities = getOwner().getWorld().getNearbyEntities(getOwner(), DISTANCE);
+		return !nearbyEntities.isEmpty();
+	}
+
+	@Override
+	public void onTick(float dt) {
+		for (Entity entity : nearbyEntities) {
+			Item item = entity.get(Item.class);
+			VanillaEntityInventory inv = getOwner().get(VanillaEntityInventory.class);
+			ArmorInventory armorInv = inv.getArmor();
+			// Check if this item is equipable armor and has more protection than the currently equipped item
+			boolean equip = false;
+			if (item.getItemStack().getMaterial() instanceof Armor) {
+				Armor armor = (Armor) item.getItemStack().getMaterial();
+				for (int i = 0; i < armorInv.size(); i++) {
+					if (armorInv.canSet(i, item.getItemStack())) {
+						ItemStack slot = armorInv.get(i);
+						if (slot != null && !(slot.getMaterial() instanceof Armor)) {
+							continue;
+						} else if (slot == null || ((Armor) slot.getMaterial()).getBaseProtection() < armor.getBaseProtection()) {
+							getOwner().getNetwork().callProtocolEvent(new EntityCollectItemEvent(getOwner(), entity));
+							if (slot != null) {
+								Item.drop(getOwner().getScene().getPosition(), slot, Vector3.ZERO);
+							}
+							armorInv.set(i, item.getItemStack(), true);
+							entity.remove();
+							equip = true;
+							break;
+						}
+					}
+				}
+			}
+			// Check if this weapon deals more damage
+			if (!equip && (item.getItemStack().getMaterial() instanceof VanillaItemMaterial || inv.getHeldItem() == null)) {
+				if (inv.getHeldItem() == null) {
+					equip = true;
+				} else if (inv.getHeldItem().getMaterial() instanceof VanillaItemMaterial) {
+					VanillaItemMaterial itemMaterial = (VanillaItemMaterial) item.getItemStack().getMaterial();
+					VanillaItemMaterial equipMaterial = (VanillaItemMaterial) inv.getHeldItem().getMaterial();
+					if (equipMaterial.getDamage() < itemMaterial.getDamage()) {
+						equip = true;
+					} else if (itemMaterial.getDamage() == equipMaterial.getDamage() && itemMaterial instanceof Tool && equipMaterial instanceof Tool
+							&& inv.getHeldItem().getData() > item.getItemStack().getData()) {
+						equip = true;
+					}
+				}
+				if (equip) {
+					getOwner().getNetwork().callProtocolEvent(new EntityCollectItemEvent(getOwner(), entity));
+					if (inv.getHeldItem() != null) {
+						Item.drop(getOwner().getScene().getPosition(), inv.getHeldItem(), Vector3.ZERO);
+					}
+					inv.getQuickbar().set(EntityQuickbarInventory.HELD_SLOT, item.getItemStack(), true);
+					entity.remove();
+					break;
+				}
+			}
+		}
+	}
+
+	protected List<Entity> getNearbyEntities() {
+		return nearbyEntities;
+	}
+}

--- a/src/main/java/org/spout/vanilla/plugin/component/misc/PlayerPickupItemComponent.java
+++ b/src/main/java/org/spout/vanilla/plugin/component/misc/PlayerPickupItemComponent.java
@@ -28,7 +28,6 @@ package org.spout.vanilla.plugin.component.misc;
 
 import java.util.List;
 
-import org.spout.api.component.type.EntityComponent;
 import org.spout.api.entity.Entity;
 
 import org.spout.vanilla.api.event.entity.EntityCollectItemEvent;
@@ -40,32 +39,11 @@ import org.spout.vanilla.plugin.configuration.VanillaConfiguration;
 /**
  * Component that adds a detector to resources.entities to scan for and pickup items.
  */
-public class PickupItemComponent extends EntityComponent {
-	private final int DISTANCE = VanillaConfiguration.ITEM_PICKUP_RANGE.getInt();
-	private List<Entity> nearbyEntities;
-	private final int WAIT_RESET = 30;
-	private int wait = 0;
-
-	@Override
-	public boolean canTick() {
-		HealthComponent healthComponent = getOwner().get(HealthComponent.class);
-		if (healthComponent != null) {
-			if (!healthComponent.isDead() && wait != 0) {
-				wait--;
-				return false;
-			}
-			if (healthComponent.isDead()) {
-				wait = WAIT_RESET;
-				return false;
-			}
-		}
-		nearbyEntities = getOwner().getWorld().getNearbyEntities(getOwner(), DISTANCE);
-		return !nearbyEntities.isEmpty();
-	}
+public class PlayerPickupItemComponent extends EntityPickupItemComponent {
 
 	@Override
 	public void onTick(float dt) {
-		for (Entity entity : nearbyEntities) {
+		for (Entity entity : getNearbyEntities()) {
 			Item item = entity.get(Item.class);
 			if (item != null && item.canBeCollected()) {
 				getOwner().getNetwork().callProtocolEvent(new EntityCollectItemEvent(getOwner(), entity));

--- a/src/main/java/org/spout/vanilla/plugin/inventory/entity/EntityArmorInventory.java
+++ b/src/main/java/org/spout/vanilla/plugin/inventory/entity/EntityArmorInventory.java
@@ -28,13 +28,40 @@ package org.spout.vanilla.plugin.inventory.entity;
 
 import org.spout.api.entity.Entity;
 import org.spout.api.inventory.ItemStack;
+import org.spout.api.material.Material;
 
 import org.spout.vanilla.api.event.entity.EntityEquipmentEvent;
 import org.spout.vanilla.api.inventory.entity.ArmorInventory;
+import org.spout.vanilla.api.material.item.armor.Boots;
+import org.spout.vanilla.api.material.item.armor.Chestplate;
+import org.spout.vanilla.api.material.item.armor.Helmet;
+import org.spout.vanilla.api.material.item.armor.Leggings;
 
+import org.spout.vanilla.plugin.material.block.solid.Pumpkin;
 import org.spout.vanilla.plugin.protocol.msg.entity.EntityEquipmentMessage;
 
 public class EntityArmorInventory extends ArmorInventory {
+
+	@Override
+	public boolean canSet(int slot, ItemStack item) {
+		if (item != null) {
+			Material material = item.getMaterial();
+			switch (slot) {
+				case BOOT_SLOT:
+					return material instanceof Boots;
+				case LEGGINGS_SLOT:
+					return material instanceof Leggings;
+				case CHEST_PLATE_SLOT:
+					return material instanceof Chestplate;
+				case HELMET_SLOT:
+					return material instanceof Helmet || material instanceof Pumpkin;
+				default:
+					return false;
+			}
+		}
+		return true;
+	}
+
 	@Override
 	public void updateSlot(int i, ItemStack item, Entity entity) {
 		final int equip;


### PR DESCRIPTION
Added new MonsterPickupitemComponent to handle logic for hostiles picking up inventory items they can wear.  Zombies, Skeletons, and PigZombies should now pickup items they walk over if they are better than items they currently have equipped, they will also pickup items into their held slot if nothing is equipped.

Signed-off-by: Nick Minkler sleaker@gmail.com
