### PR TITLE
Added enchantment mechanics on enchantment table

### DIFF
--- a/src/main/java/org/spout/vanilla/api/enchantment/ArmorEnchantment.java
+++ b/src/main/java/org/spout/vanilla/api/enchantment/ArmorEnchantment.java
@@ -31,8 +31,8 @@ import org.spout.vanilla.api.material.VanillaMaterial;
 import org.spout.vanilla.plugin.material.item.armor.Armor;
 
 public abstract class ArmorEnchantment extends Enchantment {
-	protected ArmorEnchantment(String name, int id) {
-		super(name, id);
+	protected ArmorEnchantment(String name, int id, int baseEnchantmentLevel, int deltaEnchantmentLevel, int enchantmentLevelRange) {
+		super(name, id, baseEnchantmentLevel, deltaEnchantmentLevel, enchantmentLevelRange);
 	}
 
 	@Override

--- a/src/main/java/org/spout/vanilla/api/enchantment/BowEnchantment.java
+++ b/src/main/java/org/spout/vanilla/api/enchantment/BowEnchantment.java
@@ -31,8 +31,8 @@ import org.spout.vanilla.api.material.VanillaMaterial;
 import org.spout.vanilla.plugin.material.item.tool.weapon.Bow;
 
 public abstract class BowEnchantment extends Enchantment {
-	protected BowEnchantment(String name, int id) {
-		super(name, id);
+	protected BowEnchantment(String name, int id, int baseEnchantmentLevel, int deltaEnchantmentLevel, int enchantmentLevelRange) {
+		super(name, id, baseEnchantmentLevel, deltaEnchantmentLevel, enchantmentLevelRange);
 	}
 
 	@Override

--- a/src/main/java/org/spout/vanilla/api/enchantment/Enchantment.java
+++ b/src/main/java/org/spout/vanilla/api/enchantment/Enchantment.java
@@ -28,10 +28,14 @@ package org.spout.vanilla.api.enchantment;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 
+import org.spout.api.Spout;
 import org.spout.api.inventory.ItemStack;
+import org.spout.api.math.GenericMath;
 
 import org.spout.nbt.CompoundMap;
 import org.spout.nbt.CompoundTag;
@@ -40,6 +44,8 @@ import org.spout.nbt.ShortTag;
 import org.spout.nbt.Tag;
 
 import org.spout.vanilla.api.material.VanillaMaterial;
+import org.spout.vanilla.plugin.material.item.VanillaItemMaterial;
+import org.spout.vanilla.plugin.util.MathHelper;
 
 /**
  * Represents an enchantment that can be applied to an item
@@ -47,12 +53,19 @@ import org.spout.vanilla.api.material.VanillaMaterial;
 public abstract class Enchantment {
 	private final String name;
 	private final int id;
-	private int maxLevel;
+	private int maxPowerLevel;
 	private int weight;
+	/**
+	 * Used to compute {@link getMinimumLevel} and {@link getMaximumLevel}
+	 */
+	protected final int baseEnchantmentLevel, deltaEnchantmentLevel, enchantmentLevelRange;
 
-	protected Enchantment(String name, int id) {
+	protected Enchantment(String name, int id, int baseEnchantmentLevel, int deltaEnchantmentLevel, int enchantmentLevelRange) {
 		this.name = name;
 		this.id = id;
+		this.baseEnchantmentLevel = baseEnchantmentLevel;
+		this.deltaEnchantmentLevel = deltaEnchantmentLevel;
+		this.enchantmentLevelRange = enchantmentLevelRange;
 	}
 
 	/**
@@ -62,20 +75,38 @@ public abstract class Enchantment {
 	public abstract boolean canEnchant(VanillaMaterial material);
 
 	/**
-	 * Gets the maximum level that this enchantment can be
-	 * @return maximum level
+	 * Gets the maximum power level that this enchantment can be
+	 * @return maximum power level
 	 */
-	public final int getMaximumLevel() {
-		return maxLevel;
+	public final int getMaximumPowerLevel() {
+		return maxPowerLevel;
 	}
 
 	/**
-	 * Sets the maximum level that this enchantment can be
-	 * @param maxLevel Level to set as the maximum
+	 * Sets the maximum power level that this enchantment can be
+	 * @param maxPowerLevel Level to set as the maximum
 	 */
-	public Enchantment setMaximumLevel(int maxLevel) {
-		this.maxLevel = maxLevel;
+	public Enchantment setMaximumLevel(int maxPowerLevel) {
+		this.maxPowerLevel = maxPowerLevel;
 		return this;
+	}
+
+	/**
+	 * Gets the minimum modified enchantment level allowed to produce this enchantment with a given power level
+	 * @param powerLevel The desired power level of the enchantment
+	 * @return Minimum level
+	 */
+	public int getMinimumLevel(int powerLevel) {
+		return baseEnchantmentLevel + (powerLevel - 1) * deltaEnchantmentLevel;
+	}
+
+	/**
+	 * Gets the maximum modified enchantment level allowed to produce this enchantment with a given power level
+	 * @param powerLevel The desired power level of the enchantment
+	 * @return Maximum level
+	 */
+	public int getMaximumLevel(int powerLevel) {
+		return getMinimumLevel(powerLevel) + enchantmentLevelRange;
 	}
 
 	/**
@@ -161,74 +192,82 @@ public abstract class Enchantment {
 	 * Adds the given {@link Enchantment} with the given level to the given item
 	 * @param item ItemStack to add the enchantment to
 	 * @param enchantment Enchantment to add to the item
-	 * @param level Level of the enchantment
+	 * @param powerLevel Power level of the enchantment
 	 * @param force Whether the enchantment should be forced on the item
 	 * @return Whether the enchantment was able to be added to the item
 	 */
 	@SuppressWarnings("unchecked")
-	public static boolean addEnchantment(ItemStack item, Enchantment enchantment, int level, boolean force) {
+	public static boolean addEnchantment(ItemStack item, Enchantment enchantment, int powerLevel, boolean force) {
 		VanillaMaterial material = (VanillaMaterial) item.getMaterial();
-		if (!hasEnchantment(item, enchantment)) {
-			if (!force) {
-				if (enchantment.canEnchant(material)) {
-					// Check for conflicts
-					for (Enchantment conflict : getEnchantments(item).keySet()) {
-						if (!conflict.compatibleWith(enchantment, material)) {
-							return false;
-						}
-					}
-				} else {
-					return false;
-				}
-			}
+		if (hasEnchantment(item, enchantment))
+			return false;
 
-			List<Tag<?>> enchantments = new ArrayList<Tag<?>>();
-			if (isEnchanted(item)) {
-				enchantments = ((ListTag) item.getNBTData().get("ench")).getValue();
+		if (!force) {
+			if (enchantment.canEnchant(material)) {
+				// Check for conflicts
+				for (Enchantment conflict : getEnchantments(item).keySet()) {
+					if (!conflict.compatibleWith(enchantment, material)) {
+						return false;
+					}
+				}
+			} else {
+				return false;
 			}
-			CompoundMap map = new CompoundMap();
-			map.put(new ShortTag("id", (short) enchantment.getId()));
-			map.put(new ShortTag("lvl", (short) level));
-			enchantments.add(new CompoundTag("ench", map));
-			item.setNBTData(new CompoundMap(enchantments));
-			return true;
 		}
 
-		return false;
+		CompoundMap nbtData = item.getNBTData();
+		if (nbtData == null)
+			nbtData = new CompoundMap();
+		List<CompoundTag> enchantments = new ArrayList<CompoundTag>();
+		if (nbtData.get("ench") instanceof ListTag<?>)
+			enchantments = new ArrayList<CompoundTag>(((ListTag<CompoundTag>) nbtData.get("ench")).getValue());
+		CompoundMap map = new CompoundMap();
+		map.put(new ShortTag("id", (short) enchantment.getId()));
+		map.put(new ShortTag("lvl", (short) powerLevel));
+		enchantments.add(new CompoundTag(null, map));
+		nbtData.put(new ListTag<CompoundTag>("ench", CompoundTag.class, enchantments));
+		item.setNBTData(nbtData);
+		return true;
 	}
 
 	/**
-	 * Returns the level of the given {@link Enchantment}
+	 * Returns the power level of the given {@link Enchantment}
 	 * @param item Item containing the enchantment
 	 * @param enchantment Enchantment to check
-	 * @return Level of the enchantment, or 0 if the item does not contain the enchantment
+	 * @return Power level of the enchantment, or 0 if the item does not contain the enchantment
 	 */
 	public static int getEnchantmentLevel(ItemStack item, Enchantment enchantment) {
-		return getEnchantments(item).containsKey(enchantment) ? getEnchantments(item).get(enchantment) : 0;
+		if (!isEnchanted(item))
+			return 0;
+		@SuppressWarnings("unchecked")
+		List<CompoundTag> enchantmentList = ((ListTag<CompoundTag>) item.getNBTData().get("ench")).getValue();
+		for (CompoundTag tag : enchantmentList) {
+			Tag<?> idTag = tag.getValue().get("id");
+			Tag<?> lvlTag = tag.getValue().get("lvl");
+			if (idTag instanceof ShortTag && lvlTag instanceof ShortTag && ((ShortTag) idTag).getValue() == enchantment.getId()) {
+				return (int) ((ShortTag) lvlTag).getValue();
+			}
+		}
+		return 0;
 	}
 
 	/**
 	 * Returns all {@link Enchantment}s attached to the given item
 	 * @param item Item to check
-	 * @return Map of the item's enchantments along with their level
+	 * @return Map of the item's enchantments along with their power level
 	 */
 	public static Map<Enchantment, Integer> getEnchantments(ItemStack item) {
 		Map<Enchantment, Integer> enchantments = new HashMap<Enchantment, Integer>();
-		if (!isEnchanted(item)) {
+		if (!isEnchanted(item))
 			return enchantments;
-		}
-
-		List<Short> ids = new ArrayList<Short>();
-		List<Short> levels = new ArrayList<Short>();
-		for (Tag tag : ((CompoundMap) item.getNBTData().get("ench").getValue()).values()) {
-			if (tag.getName().equals("id")) {
-				ids.add((Short) tag.getValue());
-			} else if (tag.getName().equals("lvl")) {
-				levels.add((Short) tag.getValue());
+		@SuppressWarnings("unchecked")
+		List<CompoundTag> enchantmentList = ((ListTag<CompoundTag>) item.getNBTData().get("ench")).getValue();
+		for (CompoundTag tag : enchantmentList) {
+			Tag<?> idTag = tag.getValue().get("id");
+			Tag<?> lvlTag = tag.getValue().get("lvl");
+			if (idTag instanceof ShortTag && lvlTag instanceof ShortTag) {
+				enchantments.put(EnchantmentRegistrar.getById(((ShortTag) idTag).getValue()), (int) ((ShortTag) lvlTag).getValue());
 			}
-		}
-		for (int i = 0; i < ids.size(); i++) {
-			enchantments.put(EnchantmentRegistrar.getById(ids.get(i)), (int) levels.get(i));
 		}
 		return enchantments;
 	}
@@ -240,16 +279,7 @@ public abstract class Enchantment {
 	 * @return true if the item contains the enchantment
 	 */
 	public static boolean hasEnchantment(ItemStack item, Enchantment enchantment) {
-		if (!isEnchanted(item)) {
-			return false;
-		}
-
-		for (Tag tag : ((CompoundMap) item.getNBTData().get("ench").getValue()).values()) {
-			if (tag.getName().equals("id") && ((ShortTag) tag).getValue() == enchantment.getId()) {
-				return true;
-			}
-		}
-		return false;
+		return getEnchantmentLevel(item, enchantment) > 0;
 	}
 
 	/**
@@ -259,6 +289,87 @@ public abstract class Enchantment {
 	 */
 	public static boolean isEnchanted(ItemStack item) {
 		CompoundMap nbtData = item.getNBTData();
-		return nbtData != null && nbtData.containsKey("ench");
+		return nbtData != null && nbtData.containsKey("ench") && nbtData.get("ench") instanceof ListTag<?>;
+	}
+
+	/**
+	 * An object holding both the type of {@link Enchantment} as well as its power level (I, II, III, IV, V)
+	 */
+	private final static class EnchantmentData {
+		public final Enchantment enchantment;
+		public final int powerLevel;
+
+		EnchantmentData(Enchantment enchantment, int powerLevel) {
+			this.enchantment = enchantment;
+			this.powerLevel = powerLevel;
+		}
+
+		@Override
+		public String toString() {
+			return "EnchantmentData{" + enchantment.name + ", " + powerLevel + "}";
+		}
+	}
+
+	/**
+	 * Tries to add random enchantments to an item stack
+	 * @param itemStack The item stack to enchant
+	 * @param level The level of enchantment
+	 * @return Whether enchantments were successfully added
+	 * 
+	 */
+	public static boolean addRandomEnchantments(ItemStack itemStack, int level) {
+		VanillaMaterial material = (VanillaMaterial) itemStack.getMaterial();
+		Random random = GenericMath.getRandom();
+		if (!(material instanceof VanillaItemMaterial))
+			return false;
+		int enchantibility = ((VanillaItemMaterial) material).getEnchantability();
+		// modify level depending on item enchantibility
+		level += 1 + random.nextInt(enchantibility / 4 + 1) + random.nextInt(enchantibility / 4 + 1);
+		// modify level by a random multiplier from 0.85 to 1.15 (triangular
+		// distribution)
+		float multiplier = (random.nextFloat() + random.nextFloat() - 1.0F) * 0.15F + 1.0F;
+		level = Math.max((int) ((float) level * multiplier + 0.5F), 1);
+
+		Map<EnchantmentData, Integer> enchantmentList = makeEnchantmentList(level, material);
+		boolean succeeded = false;
+		while (enchantmentList != null && !enchantmentList.isEmpty()) {
+			EnchantmentData enchantmentData = MathHelper.chooseWeightedRandom(random, enchantmentList);
+			if (enchantmentData != null) {
+				succeeded |= addEnchantment(itemStack, enchantmentData.enchantment, enchantmentData.powerLevel, false);
+				// remove any enchantments from the list which aren't compatible
+				// with the one we just added
+				for (Iterator<EnchantmentData> i = enchantmentList.keySet().iterator(); i.hasNext();) {
+					Enchantment conflict = i.next().enchantment;
+					if (!conflict.compatibleWith(enchantmentData.enchantment, material))
+						i.remove();
+				}
+			}
+			// Decide whether to add more enchantments
+			if (random.nextInt(50) > level)
+				break;
+			level /= 2;
+		}
+		return succeeded;
+	}
+
+	/**
+	 * Generates a list of allowed {@link EnchantmentData} for the given item, together with their probability weights
+	 * @param level The modified enchantment level
+	 * @param material The material of the {@link ItemStack} to be enchanted
+	 * @return A map from the allowed {@link EnchantmentData} to their probability weights
+	 */
+	private static Map<EnchantmentData, Integer> makeEnchantmentList(int level, VanillaMaterial material) {
+		Map<EnchantmentData, Integer> output = new HashMap<EnchantmentData, Integer>();
+		Enchantment[] enchantmentList = EnchantmentRegistrar.values();
+		for (Enchantment enchantment : enchantmentList) {
+			if (!enchantment.canEnchant(material))
+				continue;
+			for (int powerLevel = 1; powerLevel <= enchantment.getMaximumPowerLevel(); ++powerLevel) {
+				if (level >= enchantment.getMinimumLevel(powerLevel) && level <= enchantment.getMaximumLevel(powerLevel)) {
+					output.put(new EnchantmentData(enchantment, powerLevel), enchantment.getWeight());
+				}
+			}
+		}
+		return output;
 	}
 }

--- a/src/main/java/org/spout/vanilla/api/enchantment/EnchantmentRegistrar.java
+++ b/src/main/java/org/spout/vanilla/api/enchantment/EnchantmentRegistrar.java
@@ -75,10 +75,6 @@ public class EnchantmentRegistrar {
 	 */
 	public static Enchantment[] values() {
 		Enchantment[] values = new Enchantment[idLookup.size()];
-		for (int i = 0; i < idLookup.size(); i++) {
-			values[i] = idLookup.get(i);
-		}
-
-		return values;
+		return idLookup.values().toArray(values);
 	}
 }

--- a/src/main/java/org/spout/vanilla/api/enchantment/SwordEnchantment.java
+++ b/src/main/java/org/spout/vanilla/api/enchantment/SwordEnchantment.java
@@ -31,8 +31,8 @@ import org.spout.vanilla.api.material.VanillaMaterial;
 import org.spout.vanilla.plugin.material.item.tool.weapon.Sword;
 
 public abstract class SwordEnchantment extends Enchantment {
-	protected SwordEnchantment(String name, int id) {
-		super(name, id);
+	protected SwordEnchantment(String name, int id, int baseEnchantmentLevel, int deltaEnchantmentLevel, int enchantmentLevelRange) {
+		super(name, id, baseEnchantmentLevel, deltaEnchantmentLevel, enchantmentLevelRange);
 	}
 
 	@Override

--- a/src/main/java/org/spout/vanilla/api/enchantment/ToolEnchantment.java
+++ b/src/main/java/org/spout/vanilla/api/enchantment/ToolEnchantment.java
@@ -28,15 +28,16 @@ package org.spout.vanilla.api.enchantment;
 
 import org.spout.vanilla.api.material.VanillaMaterial;
 
-import org.spout.vanilla.plugin.material.item.tool.Tool;
+import org.spout.vanilla.plugin.material.item.tool.MiningTool;
+import org.spout.vanilla.plugin.material.item.tool.weapon.Sword;
 
 public abstract class ToolEnchantment extends Enchantment {
-	protected ToolEnchantment(String name, int id) {
-		super(name, id);
+	protected ToolEnchantment(String name, int id, int baseEnchantmentLevel, int deltaEnchantmentLevel, int enchantmentLevelRange) {
+		super(name, id, baseEnchantmentLevel, deltaEnchantmentLevel, enchantmentLevelRange);
 	}
 
 	@Override
 	public boolean canEnchant(VanillaMaterial material) {
-		return material instanceof Tool;
+		return (material instanceof MiningTool) && !(material instanceof Sword);
 	}
 }

--- a/src/main/java/org/spout/vanilla/plugin/VanillaPlugin.java
+++ b/src/main/java/org/spout/vanilla/plugin/VanillaPlugin.java
@@ -78,6 +78,7 @@ import org.spout.vanilla.plugin.configuration.InputConfiguration;
 import org.spout.vanilla.plugin.configuration.VanillaConfiguration;
 import org.spout.vanilla.plugin.configuration.WorldConfigurationNode;
 import org.spout.vanilla.api.data.VanillaData;
+import org.spout.vanilla.plugin.enchantment.VanillaEnchantments;
 import org.spout.vanilla.plugin.inventory.recipe.VanillaRecipes;
 import org.spout.vanilla.plugin.lighting.VanillaLighting;
 import org.spout.vanilla.plugin.material.VanillaBlockMaterial;
@@ -199,6 +200,7 @@ public class VanillaPlugin extends CommonPlugin {
 
 		VanillaMaterials.initialize();
 		VanillaLighting.initialize();
+		VanillaEnchantments.initialize();
 		//MapPalette.DEFAULT = (MapPalette) Spout.getFilesystem().getResource("mappalette://Vanilla/map/mapColorPalette.dat");
 		//RecipeYaml.DEFAULT = (RecipeYaml) Spout.getFilesystem().getResource("recipe://Vanilla/recipes.yml");
 		//VanillaRecipes.initialize();

--- a/src/main/java/org/spout/vanilla/plugin/command/AdministrationCommands.java
+++ b/src/main/java/org/spout/vanilla/plugin/command/AdministrationCommands.java
@@ -326,13 +326,7 @@ public class AdministrationCommands {
 			throw new CommandException(player.getDisplayName() + " does not have experience.");
 		}
 
-		if (amount > 0) {
-			level.addExperience(amount);
-		} else if (amount > 0) {
-			level.removeExperience(amount);
-		} else {
-			throw new CommandException("Argument 'amount' can not be 0.");
-		}
+		level.addExperience(amount);
 		player.sendMessage(plugin.getPrefix(), ChatStyle.BRIGHT_GREEN, "Your experience has been set to ", ChatStyle.WHITE, amount, ChatStyle.BRIGHT_GREEN, ".");
 
 	}

--- a/src/main/java/org/spout/vanilla/plugin/enchantment/VanillaEnchantments.java
+++ b/src/main/java/org/spout/vanilla/plugin/enchantment/VanillaEnchantments.java
@@ -78,4 +78,9 @@ public class VanillaEnchantments {
 	public static final Punch PUNCH = register(new Punch("Punch", 49));
 	public static final Flame FLAME = register(new Flame("Flame", 50));
 	public static final Infinity INFINITY = register(new Infinity("Infinity", 51));
+	
+	// Needed to force these enchantments to be instantiated 
+	public static void initialize() {
+		
+	}
 }

--- a/src/main/java/org/spout/vanilla/plugin/enchantment/armor/AquaAffinity.java
+++ b/src/main/java/org/spout/vanilla/plugin/enchantment/armor/AquaAffinity.java
@@ -32,7 +32,7 @@ import org.spout.vanilla.api.material.item.armor.Helmet;
 
 public class AquaAffinity extends ArmorEnchantment {
 	public AquaAffinity(String name, int id) {
-		super(name, id);
+		super(name, id, 1, 0, 40);
 		setMaximumLevel(1).setWeight(2);
 	}
 

--- a/src/main/java/org/spout/vanilla/plugin/enchantment/armor/BlastProtection.java
+++ b/src/main/java/org/spout/vanilla/plugin/enchantment/armor/BlastProtection.java
@@ -35,7 +35,7 @@ import org.spout.vanilla.plugin.enchantment.VanillaEnchantments;
 
 public class BlastProtection extends ArmorEnchantment {
 	public BlastProtection(String name, int id) {
-		super(name, id);
+		super(name, id, 5, 8, 12);
 		setMaximumLevel(4).setWeight(2);
 	}
 

--- a/src/main/java/org/spout/vanilla/plugin/enchantment/armor/FeatherFalling.java
+++ b/src/main/java/org/spout/vanilla/plugin/enchantment/armor/FeatherFalling.java
@@ -32,7 +32,7 @@ import org.spout.vanilla.api.material.item.armor.Boots;
 
 public class FeatherFalling extends ArmorEnchantment {
 	public FeatherFalling(String name, int id) {
-		super(name, id);
+		super(name, id, 5, 6, 10);
 		setMaximumLevel(4).setWeight(5);
 	}
 

--- a/src/main/java/org/spout/vanilla/plugin/enchantment/armor/FireProtection.java
+++ b/src/main/java/org/spout/vanilla/plugin/enchantment/armor/FireProtection.java
@@ -35,7 +35,7 @@ import org.spout.vanilla.plugin.enchantment.VanillaEnchantments;
 
 public class FireProtection extends ArmorEnchantment {
 	public FireProtection(String name, int id) {
-		super(name, id);
+		super(name, id, 10, 8, 12);
 		setMaximumLevel(4).setWeight(5);
 	}
 

--- a/src/main/java/org/spout/vanilla/plugin/enchantment/armor/ProjectileProtection.java
+++ b/src/main/java/org/spout/vanilla/plugin/enchantment/armor/ProjectileProtection.java
@@ -35,7 +35,7 @@ import org.spout.vanilla.plugin.enchantment.VanillaEnchantments;
 
 public class ProjectileProtection extends ArmorEnchantment {
 	public ProjectileProtection(String name, int id) {
-		super(name, id);
+		super(name, id, 3, 6, 15);
 		setMaximumLevel(4).setWeight(5);
 	}
 

--- a/src/main/java/org/spout/vanilla/plugin/enchantment/armor/Protection.java
+++ b/src/main/java/org/spout/vanilla/plugin/enchantment/armor/Protection.java
@@ -36,7 +36,7 @@ import org.spout.vanilla.plugin.enchantment.VanillaEnchantments;
 
 public class Protection extends ArmorEnchantment {
 	public Protection(String name, int id) {
-		super(name, id);
+		super(name, id, 1, 11, 20);
 		setMaximumLevel(4).setWeight(10);
 	}
 

--- a/src/main/java/org/spout/vanilla/plugin/enchantment/armor/Respiration.java
+++ b/src/main/java/org/spout/vanilla/plugin/enchantment/armor/Respiration.java
@@ -32,7 +32,7 @@ import org.spout.vanilla.api.material.item.armor.Helmet;
 
 public class Respiration extends ArmorEnchantment {
 	public Respiration(String name, int id) {
-		super(name, id);
+		super(name, id, 10, 10, 30);
 		setMaximumLevel(3).setWeight(2);
 	}
 

--- a/src/main/java/org/spout/vanilla/plugin/enchantment/armor/Thorns.java
+++ b/src/main/java/org/spout/vanilla/plugin/enchantment/armor/Thorns.java
@@ -32,7 +32,7 @@ import org.spout.vanilla.api.material.item.armor.Chestplate;
 
 public class Thorns extends ArmorEnchantment {
 	public Thorns(String name, int id) {
-		super(name, id);
+		super(name, id, 10, 20, 50);
 		setMaximumLevel(3).setWeight(1);
 	}
 

--- a/src/main/java/org/spout/vanilla/plugin/enchantment/bow/Flame.java
+++ b/src/main/java/org/spout/vanilla/plugin/enchantment/bow/Flame.java
@@ -30,7 +30,7 @@ import org.spout.vanilla.api.enchantment.BowEnchantment;
 
 public class Flame extends BowEnchantment {
 	public Flame(String name, int id) {
-		super(name, id);
+		super(name, id, 20, 0, 30);
 		setMaximumLevel(1).setWeight(2);
 	}
 }

--- a/src/main/java/org/spout/vanilla/plugin/enchantment/bow/Infinity.java
+++ b/src/main/java/org/spout/vanilla/plugin/enchantment/bow/Infinity.java
@@ -30,7 +30,7 @@ import org.spout.vanilla.api.enchantment.BowEnchantment;
 
 public class Infinity extends BowEnchantment {
 	public Infinity(String name, int id) {
-		super(name, id);
+		super(name, id, 20, 0, 30);
 		setMaximumLevel(1).setWeight(1);
 	}
 }

--- a/src/main/java/org/spout/vanilla/plugin/enchantment/bow/Power.java
+++ b/src/main/java/org/spout/vanilla/plugin/enchantment/bow/Power.java
@@ -30,7 +30,7 @@ import org.spout.vanilla.api.enchantment.BowEnchantment;
 
 public class Power extends BowEnchantment {
 	public Power(String name, int id) {
-		super(name, id);
+		super(name, id, 1, 10, 15);
 		setMaximumLevel(5).setWeight(10);
 	}
 }

--- a/src/main/java/org/spout/vanilla/plugin/enchantment/bow/Punch.java
+++ b/src/main/java/org/spout/vanilla/plugin/enchantment/bow/Punch.java
@@ -30,7 +30,7 @@ import org.spout.vanilla.api.enchantment.BowEnchantment;
 
 public class Punch extends BowEnchantment {
 	public Punch(String name, int id) {
-		super(name, id);
+		super(name, id, 12, 20, 25);
 		setMaximumLevel(2).setWeight(2);
 	}
 }

--- a/src/main/java/org/spout/vanilla/plugin/enchantment/tool/Efficiency.java
+++ b/src/main/java/org/spout/vanilla/plugin/enchantment/tool/Efficiency.java
@@ -30,7 +30,7 @@ import org.spout.vanilla.api.enchantment.ToolEnchantment;
 
 public class Efficiency extends ToolEnchantment {
 	public Efficiency(String name, int id) {
-		super(name, id);
+		super(name, id, 1, 10, 50);
 		setMaximumLevel(5).setWeight(10);
 	}
 }

--- a/src/main/java/org/spout/vanilla/plugin/enchantment/tool/Fortune.java
+++ b/src/main/java/org/spout/vanilla/plugin/enchantment/tool/Fortune.java
@@ -34,7 +34,7 @@ import org.spout.vanilla.plugin.enchantment.VanillaEnchantments;
 
 public class Fortune extends ToolEnchantment {
 	public Fortune(String name, int id) {
-		super(name, id);
+		super(name, id, 15, 9, 50);
 		setMaximumLevel(3).setWeight(2);
 	}
 

--- a/src/main/java/org/spout/vanilla/plugin/enchantment/tool/SilkTouch.java
+++ b/src/main/java/org/spout/vanilla/plugin/enchantment/tool/SilkTouch.java
@@ -34,7 +34,7 @@ import org.spout.vanilla.plugin.enchantment.VanillaEnchantments;
 
 public class SilkTouch extends ToolEnchantment {
 	public SilkTouch(String name, int id) {
-		super(name, id);
+		super(name, id, 15, 0, 50);
 		setMaximumLevel(1).setWeight(1);
 	}
 

--- a/src/main/java/org/spout/vanilla/plugin/enchantment/tool/Unbreaking.java
+++ b/src/main/java/org/spout/vanilla/plugin/enchantment/tool/Unbreaking.java
@@ -30,7 +30,7 @@ import org.spout.vanilla.api.enchantment.ToolEnchantment;
 
 public class Unbreaking extends ToolEnchantment {
 	public Unbreaking(String name, int id) {
-		super(name, id);
+		super(name, id, 5, 8, 50);
 		setMaximumLevel(3).setWeight(5);
 	}
 }

--- a/src/main/java/org/spout/vanilla/plugin/enchantment/tool/sword/BaneOfArthropods.java
+++ b/src/main/java/org/spout/vanilla/plugin/enchantment/tool/sword/BaneOfArthropods.java
@@ -34,7 +34,7 @@ import org.spout.vanilla.plugin.enchantment.VanillaEnchantments;
 
 public class BaneOfArthropods extends SwordEnchantment {
 	public BaneOfArthropods(String name, int id) {
-		super(name, id);
+		super(name, id, 5, 8, 20);
 		setMaximumLevel(5).setWeight(5);
 	}
 

--- a/src/main/java/org/spout/vanilla/plugin/enchantment/tool/sword/FireAspect.java
+++ b/src/main/java/org/spout/vanilla/plugin/enchantment/tool/sword/FireAspect.java
@@ -30,7 +30,7 @@ import org.spout.vanilla.api.enchantment.SwordEnchantment;
 
 public class FireAspect extends SwordEnchantment {
 	public FireAspect(String name, int id) {
-		super(name, id);
+		super(name, id, 10, 20, 50);
 		setMaximumLevel(2).setWeight(2);
 	}
 }

--- a/src/main/java/org/spout/vanilla/plugin/enchantment/tool/sword/Knockback.java
+++ b/src/main/java/org/spout/vanilla/plugin/enchantment/tool/sword/Knockback.java
@@ -30,7 +30,7 @@ import org.spout.vanilla.api.enchantment.SwordEnchantment;
 
 public class Knockback extends SwordEnchantment {
 	public Knockback(String name, int id) {
-		super(name, id);
+		super(name, id, 5, 20, 50);
 		setMaximumLevel(2).setWeight(5);
 	}
 }

--- a/src/main/java/org/spout/vanilla/plugin/enchantment/tool/sword/Looting.java
+++ b/src/main/java/org/spout/vanilla/plugin/enchantment/tool/sword/Looting.java
@@ -30,7 +30,7 @@ import org.spout.vanilla.api.enchantment.SwordEnchantment;
 
 public class Looting extends SwordEnchantment {
 	public Looting(String name, int id) {
-		super(name, id);
+		super(name, id, 15, 9, 50);
 		setMaximumLevel(3).setWeight(2);
 	}
 }

--- a/src/main/java/org/spout/vanilla/plugin/enchantment/tool/sword/Sharpness.java
+++ b/src/main/java/org/spout/vanilla/plugin/enchantment/tool/sword/Sharpness.java
@@ -34,7 +34,7 @@ import org.spout.vanilla.plugin.enchantment.VanillaEnchantments;
 
 public class Sharpness extends SwordEnchantment {
 	public Sharpness(String name, int id) {
-		super(name, id);
+		super(name, id, 1, 11, 20);
 		setMaximumLevel(5).setWeight(10);
 	}
 

--- a/src/main/java/org/spout/vanilla/plugin/enchantment/tool/sword/Smite.java
+++ b/src/main/java/org/spout/vanilla/plugin/enchantment/tool/sword/Smite.java
@@ -34,7 +34,7 @@ import org.spout.vanilla.plugin.enchantment.VanillaEnchantments;
 
 public class Smite extends SwordEnchantment {
 	public Smite(String name, int id) {
-		super(name, id);
+		super(name, id, 5, 8, 20);
 		setMaximumLevel(5).setWeight(5);
 	}
 

--- a/src/main/java/org/spout/vanilla/plugin/inventory/block/EnchantmentTableInventory.java
+++ b/src/main/java/org/spout/vanilla/plugin/inventory/block/EnchantmentTableInventory.java
@@ -29,8 +29,6 @@ package org.spout.vanilla.plugin.inventory.block;
 import org.spout.api.inventory.Inventory;
 import org.spout.api.inventory.ItemStack;
 
-import org.spout.vanilla.api.inventory.window.prop.EnchantmentTableProperty;
-
 import org.spout.vanilla.plugin.material.item.VanillaItemMaterial;
 
 /**
@@ -40,7 +38,6 @@ public class EnchantmentTableInventory extends Inventory {
 	private static final long serialVersionUID = 1L;
 	public static final int SIZE = 1;
 	public static final int SLOT = 0;
-	private final int[] levels = new int[3];
 
 	public EnchantmentTableInventory() {
 		super(SIZE);
@@ -62,41 +59,7 @@ public class EnchantmentTableInventory extends Inventory {
 		return get(SLOT);
 	}
 
-	/**
-	 * Returns the level of the enchantment in the given slot.
-	 * @param slot Slot to check
-	 * @return Level of the the enchantment
-	 */
-	public int getEnchantmentLevel(int slot) {
-		if (slot < 0 || slot > 2) {
-			throw new IllegalArgumentException("Slot must be between 0 and 2");
-		}
-
-		return levels[slot];
-	}
-
-	/**
-	 * Sets the level of the enchantment in the given {@link EnchantmentTableProperty} slot.
-	 * @param slot Slot to set, null to clear the
-	 * @param level Level of the enchantment
-	 */
-	public void setEnchantmentLevel(EnchantmentTableProperty slot, int level) {
-		setEnchantmentLevel(slot.getId(), level);
-	}
-
-	/**
-	 * Sets the level of the enchantment in the given slot.
-	 * @param slot Slot to set
-	 * @param level Level of the enchantment
-	 */
-	public void setEnchantmentLevel(int slot, int level) {
-		if (slot < 0 || slot > 2) {
-			throw new IllegalArgumentException("Slot must be between 0 and 2");
-		}
-
-		levels[slot] = level;
-	}
-
+	//TODO: Change this to vanilla behaviour (accept any item here, but only 1)
 	@Override
 	public boolean canSet(int i, ItemStack item) {
 		return item.getMaterial() instanceof VanillaItemMaterial && ((VanillaItemMaterial) item.getMaterial()).isEnchantable();

--- a/src/main/java/org/spout/vanilla/plugin/material/item/tool/MiningTool.java
+++ b/src/main/java/org/spout/vanilla/plugin/material/item/tool/MiningTool.java
@@ -45,6 +45,7 @@ public class MiningTool extends Tool {
 		super(name, id, toolLevel.getMaxDurability(), toolType, null);
 		this.toolLevel = toolLevel;
 		this.diggingSpeed = toolLevel.getDiggingSpeed();
+		this.setEnchantability(toolLevel.getEnchantability());
 	}
 
 	@Override

--- a/src/main/java/org/spout/vanilla/plugin/material/item/tool/weapon/Sword.java
+++ b/src/main/java/org/spout/vanilla/plugin/material/item/tool/weapon/Sword.java
@@ -33,6 +33,6 @@ import org.spout.vanilla.plugin.material.item.tool.MiningTool;
 public class Sword extends MiningTool {
 	public Sword(String name, int id, ToolLevel toolLevel) {
 		super(name, id, toolLevel, ToolType.SWORD);
-		this.setDamage(4 + toolLevel.getDamageBonus()).setEnchantability(toolLevel.getEnchantability());
+		this.setDamage(4 + toolLevel.getDamageBonus());
 	}
 }

--- a/src/main/java/org/spout/vanilla/plugin/util/MathHelper.java
+++ b/src/main/java/org/spout/vanilla/plugin/util/MathHelper.java
@@ -26,6 +26,7 @@
  */
 package org.spout.vanilla.plugin.util;
 
+import java.util.Map;
 import java.util.Random;
 
 import org.spout.api.math.GenericMath;
@@ -54,8 +55,8 @@ public class MathHelper {
 	}
 
 	/**
-	 * Gets the (real?) celestial angle at a certain time of the day<br> The use
-	 * of this function is unknown...
+	 * Gets the (real?) celestial angle at a certain time of the day<br>
+	 * The use of this function is unknown...
 	 * @param timeMillis time
 	 * @param timeMillisTune fine runing
 	 * @return celestial angle, a value from 0 to 1
@@ -105,5 +106,26 @@ public class MathHelper {
 
 	public static float getLookAtPitch(Vector3 offset) {
 		return (float) -Math.toDegrees(Math.atan(offset.getY() / GenericMath.length(offset.getX(), offset.getZ())));
+	}
+
+	/**
+	 * Chooses an item randomly from a list, with the probability of each item proportional to its given weight
+	 * @param random The random number generator to be used
+	 * @param weightMap A map from the items that can be chosen to their respective weights
+	 * @return The randomly chosen item, or null if the total weight is not positive.
+	 */
+	public static <T> T chooseWeightedRandom(Random random, Map<T, Integer> weightMap) {
+		int totalWeight = 0;
+		for (Integer i : weightMap.values())
+			totalWeight += i;
+		if (totalWeight <= 0)
+			return null;
+		int j = random.nextInt(totalWeight);
+		for (T t : weightMap.keySet()) {
+			j -= weightMap.get(t);
+			if (j < 0)
+				return t;
+		}
+		return null;
 	}
 }

--- a/src/test/java/org/spout/vanilla/item/EnchantmentTest.java
+++ b/src/test/java/org/spout/vanilla/item/EnchantmentTest.java
@@ -1,0 +1,83 @@
+/*
+ * This file is part of Vanilla.
+ *
+ * Copyright (c) 2011-2012, Spout LLC <http://www.spout.org/>
+ * Vanilla is licensed under the Spout License Version 1.
+ *
+ * Vanilla is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * In addition, 180 days after any changes are published, you can use the
+ * software, incorporating those changes, under the terms of the MIT license,
+ * as described in the Spout License Version 1.
+ *
+ * Vanilla is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License,
+ * the MIT license and the Spout License Version 1 along with this program.
+ * If not, see <http://www.gnu.org/licenses/> for the GNU Lesser General Public
+ * License and see <http://spout.in/licensev1> for the full license, including
+ * the MIT license.
+ */
+package org.spout.vanilla.item;
+
+import java.util.Map;
+
+import org.junit.Test;
+
+import org.spout.api.inventory.ItemStack;
+
+import org.spout.vanilla.plugin.material.VanillaMaterials;
+import org.spout.vanilla.api.enchantment.Enchantment;
+import org.spout.vanilla.api.enchantment.EnchantmentRegistrar;
+import org.spout.vanilla.plugin.enchantment.VanillaEnchantments;
+
+import static org.junit.Assert.assertTrue;
+
+public class EnchantmentTest {
+	@Test
+	public void testEnchantmentsList() {
+		Enchantment[] list = EnchantmentRegistrar.values();
+		assertTrue(list.length > 0);
+		for (Enchantment enchantment : list)
+			assertTrue(enchantment != null);
+	}
+
+	@Test
+	public void testAddEnchantmentPick() {
+		assertTrue(VanillaEnchantments.UNBREAKING.canEnchant(VanillaMaterials.DIAMOND_PICKAXE));
+		ItemStack itemStack = new ItemStack(VanillaMaterials.DIAMOND_PICKAXE, 1);
+		Enchantment.addEnchantment(itemStack, VanillaEnchantments.EFFICIENCY, 3, false);
+		Enchantment.addEnchantment(itemStack, VanillaEnchantments.FORTUNE, 2, false);
+		Map<Enchantment, Integer> enchantments = Enchantment.getEnchantments(itemStack);
+		assertTrue(enchantments.size() == 2);
+		assertTrue(enchantments.containsKey(VanillaEnchantments.EFFICIENCY));
+		assertTrue(enchantments.get(VanillaEnchantments.EFFICIENCY) == 3);
+		assertTrue(Enchantment.getEnchantmentLevel(itemStack, VanillaEnchantments.FORTUNE) == 2);
+	}
+
+	@Test
+	public void testEnchantmentBow() {
+		ItemStack itemStack = new ItemStack(VanillaMaterials.BOW, 1);
+		Enchantment.addEnchantment(itemStack, VanillaEnchantments.PUNCH, 2, false);
+		Enchantment.addEnchantment(itemStack, VanillaEnchantments.FORTUNE, 2, false);
+		assertTrue(!VanillaEnchantments.FORTUNE.canEnchant(VanillaMaterials.BOW));
+		assertTrue(Enchantment.getEnchantmentLevel(itemStack, VanillaEnchantments.PUNCH) == 2);
+		assertTrue(Enchantment.getEnchantmentLevel(itemStack, VanillaEnchantments.FORTUNE) == 0);
+	}
+
+	@Test
+	public void testEnchantmentSword() {
+		ItemStack itemStack = new ItemStack(VanillaMaterials.DIAMOND_SWORD, 1);
+		Enchantment.addEnchantment(itemStack, VanillaEnchantments.KNOCKBACK, 2, false);
+		Enchantment.addEnchantment(itemStack, VanillaEnchantments.FORTUNE, 2, false);
+		assertTrue(!VanillaEnchantments.FORTUNE.canEnchant(VanillaMaterials.DIAMOND_SWORD));
+		assertTrue(Enchantment.getEnchantmentLevel(itemStack, VanillaEnchantments.KNOCKBACK) == 2);
+		assertTrue(Enchantment.getEnchantmentLevel(itemStack, VanillaEnchantments.FORTUNE) == 0);
+	}
+}


### PR DESCRIPTION
*Added methods to api/enchantment/Enchantment.java to generate and add random enchantments
*Logic based on Minecraft 1.4.7
*Changed "enchantment level" to "power level" in places to distinguish between the power level of an enchantment (I, II, III, IV, V) and the enchantment level displayed in the enchantment interface (1 to 30)
*Fixed bug in Enchantments.values(), which was assuming the enchantment ids were consecutive
*Fixed bug in Enchantment.addEnchantment etc, which weren't putting the NBT data in the correct format (http://www.minecraftwiki.net/wiki/Player.dat_Format#Item_structure)
*Fixed bug in ToolEnchantment.canEnchant (returned true on bows and swords)
*Simplified xp code
*Update EnchantmentTable's level display when it changes, rather than every tick
*Allow bookshelves on one side of table to contribute despite blocks on the other side (still not quite identical to Vanilla)
*Moved enchantment levels from EnchantmentTableInventory to EnchantmentTableWindow
*Fixed bug in Window.handleClick, event should be cancelled if the slot cannot be set
*Added tests EnchantmentTest and LevelComponentTest
Signed-off-by: stewbasic stewbasic@gmail.com
