### PR TITLE
Cleanup how inventories are dropped

### DIFF
--- a/src/main/java/org/spout/vanilla/api/component/inventory/EntityInventoryComponent.java
+++ b/src/main/java/org/spout/vanilla/api/component/inventory/EntityInventoryComponent.java
@@ -26,6 +26,9 @@
  */
 package org.spout.vanilla.api.component.inventory;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.spout.api.component.type.EntityComponent;
 import org.spout.api.inventory.Inventory;
 import org.spout.api.inventory.ItemStack;
@@ -68,6 +71,17 @@ public abstract class EntityInventoryComponent extends EntityComponent {
 		if (inv != null) {
 			inv.updateAll();
 		}
+	}
+
+	/**
+	 * Returns a List of all inventories that are dropped when the component owner is removed.
+	 * @return list of droppable inventories
+	 */
+	public List<Inventory> getDroppable() {
+		List<Inventory> inventories = new ArrayList<Inventory>(2);
+		inventories.add(getArmor());
+		inventories.add(getQuickbar());
+		return inventories;
 	}
 
 	/**

--- a/src/main/java/org/spout/vanilla/api/component/inventory/PlayerInventoryComponent.java
+++ b/src/main/java/org/spout/vanilla/api/component/inventory/PlayerInventoryComponent.java
@@ -30,6 +30,9 @@ import org.spout.api.inventory.Inventory;
 import org.spout.api.inventory.ItemStack;
 
 import org.spout.vanilla.api.inventory.entity.ArmorInventory;
+
+import java.util.ArrayList;
+import java.util.List;
 import org.spout.vanilla.plugin.inventory.player.PlayerCraftingInventory;
 
 /**
@@ -82,5 +85,15 @@ public abstract class PlayerInventoryComponent extends EntityInventoryComponent 
 		if (inv != null) {
 			inv.updateAll();
 		}
+	}
+
+	@Override
+	public List<Inventory> getDroppable() {
+		List<Inventory> inventories = new ArrayList<Inventory>(5);
+		inventories.add(getQuickbar());
+		inventories.add(getArmor());
+		inventories.add(getCraftingGrid());
+		inventories.add(getMain());
+		return inventories;
 	}
 }


### PR DESCRIPTION
adds getDroppable() to EntityInventoryComponent.
Moves logic for dropping items to seperate methods in HealthComponent for fluidity.

Signed-off-by: Nick Minkler sleaker@gmail.com
