### PR TITLE
Use inputState.pitch() instead of ts.getRotation().getPitch()

### DIFF
--- a/src/main/java/org/spout/vanilla/input/VanillaInputExecutor.java
+++ b/src/main/java/org/spout/vanilla/input/VanillaInputExecutor.java
@@ -70,7 +70,7 @@ public class VanillaInputExecutor implements InputExecutor {
 		}
 
 		player.get(EntityHead.class).setOrientation(QuaternionMath.rotation(inputState.pitch(), inputState.yaw(), ts.getRotation().getRoll()));
-		ts.translateAndSetRotation(offset, QuaternionMath.rotation(ts.getRotation().getPitch(), inputState.yaw(), ts.getRotation().getRoll()));
+		ts.translateAndSetRotation(offset, QuaternionMath.rotation(inputState.pitch(), inputState.yaw(), ts.getRotation().getRoll()));
 		sc.setTransform(ts);
 	}
 }


### PR DESCRIPTION
- Fixes up and down not being recognized but still reacts oddly when
  clicking on blocks with Spout Client
  Signed-off-by: Steven Downer grinch@outlook.com
