### PR TITLE
Replace all instances of <p/> with <p> to follow Oracle standards.

### DIFF
--- a/src/main/java/org/spout/vanilla/ai/action/ActionAttack.java
+++ b/src/main/java/org/spout/vanilla/ai/action/ActionAttack.java
@@ -38,7 +38,7 @@ import org.spout.vanilla.ai.sensor.NearbyComponentsSensor;
 
 /**
  * Very basic Attack action that directs the Entity to go attack the player that is nearby.
- * <p/>
+ * <p>
  * The attack is simply the Entity colliding with the player. Actual attack damage is done within
  * onCollided.
  */

--- a/src/main/java/org/spout/vanilla/ai/sensor/NearbyComponentsSensor.java
+++ b/src/main/java/org/spout/vanilla/ai/sensor/NearbyComponentsSensor.java
@@ -39,7 +39,7 @@ import org.spout.vanilla.component.entity.VanillaEntityComponent;
 
 /**
  * Simple Sensor that detects Entities with a specified Component nearby.
- * <p/>
+ * <p>
  * TODO Probably should have some sort of sight limitation on this sensor. Would be a great optimization.
  */
 public class NearbyComponentsSensor implements Sensor {

--- a/src/main/java/org/spout/vanilla/component/entity/VanillaEntityComponent.java
+++ b/src/main/java/org/spout/vanilla/component/entity/VanillaEntityComponent.java
@@ -48,10 +48,10 @@ public class VanillaEntityComponent extends EntityComponent {
 
 	/**
 	 * A counter of how many times this component has been attached to an entity
-	 * <p/>
+	 * <p>
 	 * Values > 1 indicate how many times this component has been saved to disk,
 	 * and reloaded
-	 * <p/>
+	 * <p>
 	 * Values == 1 indicate a new component that has never been saved and loaded.
 	 * @return attached count
 	 */

--- a/src/main/java/org/spout/vanilla/component/entity/player/HUD.java
+++ b/src/main/java/org/spout/vanilla/component/entity/player/HUD.java
@@ -77,7 +77,7 @@ public class HUD extends VanillaEntityComponent {
 	/**
 	 * Will update the class used for each part of the HUD
 	 * Will not replace a class if one already is placed
-	 * <p/>
+	 * <p>
 	 * To replace use setDefault(Class clazz, boolean force)
 	 * @param clazz
 	 */
@@ -87,7 +87,7 @@ public class HUD extends VanillaEntityComponent {
 
 	/**
 	 * Will update the class used for each part of the HUD
-	 * <p/>
+	 * <p>
 	 * Second param is to force the update, a false will only update the
 	 * class if a class isn't already placed, true will replace any class
 	 * and force an update (forced update not implemented yet)
@@ -175,7 +175,7 @@ public class HUD extends VanillaEntityComponent {
 
 	/**
 	 * Sets the amount of armor to display.
-	 * <p/>
+	 * <p>
 	 * This method will be removed once armor is handled by Vanilla
 	 */
 	public void setArmor() {
@@ -194,7 +194,7 @@ public class HUD extends VanillaEntityComponent {
 
 	/**
 	 * Modify the advancement of the xp bar.
-	 * <p/>
+	 * <p>
 	 * This method needs to be removed when experience is handled by
 	 * Vanilla code.
 	 */

--- a/src/main/java/org/spout/vanilla/event/block/RedstoneChangeEvent.java
+++ b/src/main/java/org/spout/vanilla/event/block/RedstoneChangeEvent.java
@@ -48,7 +48,7 @@ public class RedstoneChangeEvent extends BlockEvent implements Cancellable {
 
 	/**
 	 * Gets the redstone power level before the block change occurred.
-	 * <p/>
+	 * <p>
 	 * <p>Note: Because RedstoneChangeEvent occurs <i>before</i> the block
 	 * change event has finished, you can also inspect the block to find the
 	 * previous power.</p>
@@ -61,7 +61,7 @@ public class RedstoneChangeEvent extends BlockEvent implements Cancellable {
 	/**
 	 * Gets the new power level the redstone source will have after this
 	 * block change finishes.
-	 * <p/>
+	 * <p>
 	 * <p>Note: Because RedstoneChangeEvent occurs <i>before</i> the block
 	 * change event has finished, neighbor blocks may not yet report that they
 	 * are powered. To perform an event after a redstone change, use the scheduler.</p>
@@ -74,7 +74,7 @@ public class RedstoneChangeEvent extends BlockEvent implements Cancellable {
 	/**
 	 * Sets the new power level the redstone source will have after this
 	 * block change finishes.
-	 * <p/>
+	 * <p>
 	 * <p>Note: Because RedstoneChangeEvent occurs <i>before</i> the block
 	 * change event has finished, neighbor blocks may not yet report that they
 	 * are powered. To perform an event after a redstone change, use the scheduler.</p>

--- a/src/main/java/org/spout/vanilla/material/block/SpreadingSolid.java
+++ b/src/main/java/org/spout/vanilla/material/block/SpreadingSolid.java
@@ -91,7 +91,7 @@ public abstract class SpreadingSolid extends Solid implements Spreading, Dynamic
 
 	/**
 	 * Tests if the block can decay at the block specified<br><br>
-	 * <p/>
+	 * <p>
 	 * <b>Note: This should not operate on the block itself,
 	 * as the block is not necessarily this material</b>
 	 * @param block of this Spreading solid

--- a/src/main/java/org/spout/vanilla/protocol/rcon/RemoteConnectionCore.java
+++ b/src/main/java/org/spout/vanilla/protocol/rcon/RemoteConnectionCore.java
@@ -35,7 +35,7 @@ import org.spout.vanilla.protocol.rcon.handler.RconHandlerLookupService;
 
 /**
  * Core interface for the rcon system
- * <p/>
+ * <p>
  * This has most of the stuff needed for a client implementation, but that has not been done yet.
  */
 public abstract class RemoteConnectionCore implements Closeable {

--- a/src/main/java/org/spout/vanilla/protocol/rcon/msg/AuthMessage.java
+++ b/src/main/java/org/spout/vanilla/protocol/rcon/msg/AuthMessage.java
@@ -28,7 +28,7 @@ package org.spout.vanilla.protocol.rcon.msg;
 
 /**
  * Message used for initial authentication
- * <p/>
+ * <p>
  * Payload: password
  */
 public class AuthMessage extends RconMessage {

--- a/src/main/java/org/spout/vanilla/protocol/rcon/msg/CommandMessage.java
+++ b/src/main/java/org/spout/vanilla/protocol/rcon/msg/CommandMessage.java
@@ -28,7 +28,7 @@ package org.spout.vanilla.protocol.rcon.msg;
 
 /**
  * Packet sent by the client with a command
- * <p/>
+ * <p>
  * Payload: Command text
  */
 public class CommandMessage extends RconMessage {

--- a/src/main/java/org/spout/vanilla/protocol/rcon/msg/CommandResponseMessage.java
+++ b/src/main/java/org/spout/vanilla/protocol/rcon/msg/CommandResponseMessage.java
@@ -28,7 +28,7 @@ package org.spout.vanilla.protocol.rcon.msg;
 
 /**
  * Message sent by the server with a command response
- * <p/>
+ * <p>
  * Payload: Command response text
  */
 public class CommandResponseMessage extends RconMessage {

--- a/src/main/java/org/spout/vanilla/util/explosion/ExplosionModel.java
+++ b/src/main/java/org/spout/vanilla/util/explosion/ExplosionModel.java
@@ -70,17 +70,17 @@ public abstract class ExplosionModel {
 
 	/**
 	 * Calculated with the following:
-	 * <p/>
+	 * <p>
 	 * o: Origin of explosion
 	 * p: Location of entity for impact to be calculated for
 	 * s: The damage radius
 	 * di: distance from origin
 	 * de: density of non-air blocks from the position to the origin
 	 * i: impact of explosion
-	 * <p/>
+	 * <p>
 	 * 1. Calculate impact with <code>i = (1 - di / size) * de</code>
 	 * 2. Return <code>(int) ((i * i + i) / 2 * 8 * size + 1)</code>
-	 * <p/>
+	 * <p>
 	 * Example:
 	 * M
 	 * @param o


### PR DESCRIPTION
As per the link below, the standard for using paragraph tags it to simply use `<p>` and not use closing tags.

http://www.oracle.com/technetwork/java/javase/documentation/index-137868.html#format

Signed-off-by: Steven Downer grinch@outlook.com
