### PR TITLE
Fixup for ATTACHED_COUNT

### DIFF
--- a/src/main/java/org/spout/vanilla/component/entity/VanillaEntityComponent.java
+++ b/src/main/java/org/spout/vanilla/component/entity/VanillaEntityComponent.java
@@ -27,6 +27,7 @@
 package org.spout.vanilla.component.entity;
 
 import java.util.Arrays;
+import java.util.HashMap;
 
 import org.spout.api.component.entity.EntityComponent;
 import org.spout.api.util.Parameter;
@@ -36,9 +37,16 @@ import org.spout.vanilla.event.entity.network.EntityMetaChangeEvent;
 
 public class VanillaEntityComponent extends EntityComponent {
 	@Override
+	@SuppressWarnings("unchecked")
 	public void onAttached() {
-		//Tracks the number of times this component has been attached (i.e how many times it's been saved, then loaded. 1 = fresh entity)
-		getOwner().getData().put(VanillaData.ATTACHED_COUNT, getAttachedCount() + 1);
+		HashMap<Class<? extends VanillaEntityComponent>, Integer> map = getOwner().getData().get(VanillaData.ATTACHED_COUNT);
+		Integer count = map.get(getClass());
+		if (count == null) {
+			count = 0;
+		}
+		count++;
+		map.put(getClass(), count);
+		getOwner().getData().put(VanillaData.ATTACHED_COUNT, map);
 		getOwner().setSavable(true);
 	}
 
@@ -47,12 +55,15 @@ public class VanillaEntityComponent extends EntityComponent {
 	}
 
 	/**
-	 * A counter of how many times this component has been attached to an entity <p> Values > 1 indicate how many times this component has been saved to disk, and reloaded <p> Values == 1 indicate a new
-	 * component that has never been saved and loaded.
+	 * A counter of how many times this component has been attached to an entity
+	 * <p>
+	 * Values > 1 indicate how many times this component has been saved to disk, and reloaded
+	 * <p>
+	 * Values == 1 indicate a new component that has never been saved and loaded.
 	 *
 	 * @return attached count
 	 */
 	public final int getAttachedCount() {
-		return getOwner().getData().get(VanillaData.ATTACHED_COUNT);
+		return (Integer) getOwner().getData().get(VanillaData.ATTACHED_COUNT).get(getClass());
 	}
 }

--- a/src/main/java/org/spout/vanilla/component/entity/living/Human.java
+++ b/src/main/java/org/spout/vanilla/component/entity/living/Human.java
@@ -67,8 +67,6 @@ import org.spout.vanilla.protocol.msg.player.PlayerGameStateMessage;
  * A component that identifies the entity as a Vanilla player.
  */
 public class Human extends Living {
-	public static final int SPAWN_HEALTH = 20;
-
 	@Override
 	public void onAttached() {
 		super.onAttached();
@@ -76,12 +74,8 @@ public class Human extends Living {
 		holder.add(PlayerItemCollector.class);
 		holder.add(Digging.class);
 		holder.getNetwork().setEntityProtocol(VanillaPlugin.VANILLA_PROTOCOL_ID, new HumanEntityProtocol());
-		//Add height offset if loading from disk
-		//		if (holder instanceof Player) {
-		//			((Player) holder).teleport(holder.getTransform().getPosition().add(0, 1.85F, 0));
-		//		}
 		if (getAttachedCount() == 1) {
-			holder.add(Health.class).setSpawnHealth(SPAWN_HEALTH);
+			holder.add(Health.class).setSpawnHealth(20);
 		}
 		TextModelComponent textModel = getOwner().get(TextModelComponent.class);
 		if (textModel != null) {

--- a/src/main/java/org/spout/vanilla/component/entity/living/Living.java
+++ b/src/main/java/org/spout/vanilla/component/entity/living/Living.java
@@ -59,7 +59,6 @@ public abstract class Living extends VanillaEntityComponent {
 		navigation.setDefaultExaminers(new VanillaBlockExaminer());
 		ai = holder.add(GoapAIComponent.class);
 		holder.add(Burn.class);
-		holder.setSavable(true);
 	}
 
 	public boolean isOnGround() {

--- a/src/main/java/org/spout/vanilla/component/entity/living/passive/Ocelot.java
+++ b/src/main/java/org/spout/vanilla/component/entity/living/passive/Ocelot.java
@@ -68,7 +68,6 @@ public class Ocelot extends Animal implements Passive {
 	}
 
 	public byte getSkinId() {
-		System.out.println(getOwner().getData().get(VanillaData.OCELOT_SKIN));
 		return getOwner().getData().get(VanillaData.OCELOT_SKIN);
 	}
 

--- a/src/main/java/org/spout/vanilla/component/entity/misc/Health.java
+++ b/src/main/java/org/spout/vanilla/component/entity/misc/Health.java
@@ -314,6 +314,7 @@ public class Health extends VanillaEntityComponent {
 	 */
 	public void setMaxHealth(int maxHealth) {
 		getData().put(VanillaData.MAX_HEALTH, maxHealth);
+		//TODO: Add event for max health change
 	}
 
 	/**
@@ -323,8 +324,7 @@ public class Health extends VanillaEntityComponent {
 	 */
 	public void setSpawnHealth(int maxHealth) {
 		this.setMaxHealth(maxHealth);
-		//Do not call setHealth yet, network has not been initialized if loading from file
-		getData().put(VanillaData.HEALTH, maxHealth);
+		this.setHealth(maxHealth, HealthChangeCause.SPAWN);
 	}
 
 	/**

--- a/src/main/java/org/spout/vanilla/component/entity/substance/Item.java
+++ b/src/main/java/org/spout/vanilla/component/entity/substance/Item.java
@@ -55,7 +55,9 @@ public class Item extends Substance {
 		getOwner().getNetwork().setEntityProtocol(VanillaPlugin.VANILLA_PROTOCOL_ID, new ItemEntityProtocol());
 		PhysicsComponent physics = getOwner().getPhysics();
 		physics.activate(1f, new BoxShape(0.27f, 0.27f, 0.27f), false, true);
-		getOwner().add(Health.class).setMaxHealth(20);
+		if (getAttachedCount() == 1) {
+			getOwner().add(Health.class).setSpawnHealth(20);
+		}
 	}
 
 	@Override

--- a/src/main/java/org/spout/vanilla/component/entity/substance/Painting.java
+++ b/src/main/java/org/spout/vanilla/component/entity/substance/Painting.java
@@ -51,7 +51,6 @@ public class Painting extends Substance {
 		if (getAttachedCount() == 1) {
 			getOwner().add(DeathDrops.class).addDrop(new ItemStack(VanillaMaterials.PAINTING, 1));
 		}
-		getOwner().setSavable(true);
 	}
 
 	@Override

--- a/src/main/java/org/spout/vanilla/component/entity/substance/vehicle/minecart/MinecartBase.java
+++ b/src/main/java/org/spout/vanilla/component/entity/substance/vehicle/minecart/MinecartBase.java
@@ -53,7 +53,6 @@ public abstract class MinecartBase extends Substance {
 		if (getAttachedCount() == 1) {
 			getOwner().add(DeathDrops.class).addDrop(new ItemStack(VanillaMaterials.MINECART, 1));
 		}
-		getOwner().setSavable(true);
 	}
 
 	@Override

--- a/src/main/java/org/spout/vanilla/data/VanillaData.java
+++ b/src/main/java/org/spout/vanilla/data/VanillaData.java
@@ -26,6 +26,8 @@
  */
 package org.spout.vanilla.data;
 
+import java.util.HashMap;
+
 import org.spout.api.inventory.ItemStack;
 import org.spout.api.map.DefaultedKey;
 import org.spout.api.map.DefaultedKeyArray;
@@ -35,6 +37,7 @@ import org.spout.api.material.block.BlockFace;
 import org.spout.api.math.Quaternion;
 import org.spout.api.math.Vector3;
 
+import org.spout.vanilla.component.entity.VanillaEntityComponent;
 import org.spout.vanilla.data.effect.EntityEffectType;
 import org.spout.vanilla.inventory.block.BrewingStandInventory;
 import org.spout.vanilla.inventory.block.ChestInventory;
@@ -45,7 +48,6 @@ import org.spout.vanilla.inventory.block.HopperInventory;
 import org.spout.vanilla.inventory.entity.EntityArmorInventory;
 import org.spout.vanilla.inventory.entity.EntityQuickbarInventory;
 import org.spout.vanilla.inventory.player.DropInventory;
-import org.spout.vanilla.inventory.player.PlayerArmorInventory;
 import org.spout.vanilla.inventory.player.PlayerCraftingInventory;
 import org.spout.vanilla.inventory.player.PlayerMainInventory;
 import org.spout.vanilla.inventory.player.PlayerQuickbar;
@@ -102,7 +104,7 @@ public class VanillaData {
 	public static final DefaultedKey<Float> MAX_UPDATE_DELAY = new DefaultedKeyImpl<Float>("max_update_delay", 4f);
 	public static final DefaultedKey<Float> EFFECT_DURATION = new DefaultedKeyImpl<Float>("effect_duration", 9f);
 	//Entity data
-	public static final DefaultedKey<Integer> ATTACHED_COUNT = new DefaultedKeyImpl<Integer>("attached_count", 0);
+	public static final DefaultedKey<HashMap> ATTACHED_COUNT = new DefaultedKeyImpl<HashMap>("attached_count", new HashMap<Class<? extends VanillaEntityComponent>, Integer>());
 	public static final DefaultedKey<Boolean> IS_FALLING = new DefaultedKeyImpl<Boolean>("is_falling", false);
 	public static final DefaultedKey<Boolean> IS_ON_GROUND = new DefaultedKeyImpl<Boolean>("is_on_Ground", true);
 	public static final DefaultedKey<Boolean> IS_JUMPING = new DefaultedKeyImpl<Boolean>("is_jumping", false);
@@ -208,7 +210,6 @@ public class VanillaData {
 	public static final DefaultedKey<EntityQuickbarInventory> ENTITY_HELD_INVENTORY = new DefaultedKeyFactory<EntityQuickbarInventory>("held", EntityQuickbarInventory.class);
 	public static final DefaultedKey<PlayerMainInventory> MAIN_INVENTORY = new DefaultedKeyFactory<PlayerMainInventory>("main", PlayerMainInventory.class);
 	public static final DefaultedKey<PlayerCraftingInventory> CRAFTING_INVENTORY = new DefaultedKeyFactory<PlayerCraftingInventory>("crafting", PlayerCraftingInventory.class);
-	public static final DefaultedKey<PlayerArmorInventory> PLAYER_ARMOR_INVENTORY = new DefaultedKeyFactory<PlayerArmorInventory>("armor", PlayerArmorInventory.class);
 	public static final DefaultedKey<PlayerQuickbar> QUICKBAR_INVENTORY = new DefaultedKeyFactory<PlayerQuickbar>("quickbar", PlayerQuickbar.class);
 	public static final DefaultedKey<ChestInventory> ENDER_CHEST_INVENTORY = new DefaultedKeyFactory<ChestInventory>("ender_chest_inventory", ChestInventory.class);
 	public static final DefaultedKey<DropInventory> DROP_INVENTORY = new DefaultedKeyFactory<DropInventory>("drops", DropInventory.class);

--- a/src/main/java/org/spout/vanilla/material/item/misc/ItemFrameItem.java
+++ b/src/main/java/org/spout/vanilla/material/item/misc/ItemFrameItem.java
@@ -51,11 +51,9 @@ public class ItemFrameItem extends VanillaItemMaterial {
 
 		World world = block.getWorld();
 		Point pos = block.getPosition();
-		System.out.println("Position: " + pos);
 		Entity e = world.createEntity(new Point(world, pos.getBlockX(), pos.getBlockY(), pos.getBlockZ()), ItemFrame.class);
 		ItemFrame frame = e.add(ItemFrame.class);
 		frame.setOrientation(face);
-		System.out.println("Spawning");
 		world.spawnEntity(e);
 	}
 }


### PR DESCRIPTION
- Created HashMap that stores the class and the attached count. This should make sure that when checking the attached count of a class, it always returns that classes attached count and not an overall number.
- Made setSpawnHealth do setHealth with the SPAWN cause.
- Removed some unneeded code.
- Added TODO for MaxHealthChangedEvent
- Removed setSavable calls from compoments as the parent already does this.

Signed-off-by: Steven Downer grinch@outlook.com
