### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,7 @@ env:
   global:
     - secure: "i/7ILQcFGsvVn8pn/s32gwXTfYCPMSZY1djuSygM2IiUIux3XS+MpKQb9K7SM6d3lFGiuxUQ0o9hDZ1r0s4Va1HOd55/98ROEixob94y9cb/GmLmbiZAyZ19gAF7s5V/K6uqZfe4IEPuZoMMyjcQNKelxJ+kRnP9qZBDcI23ZIM="
     - secure: "t/ByMFK4grv1EjkuF6ygbEtZpsKDHaIFJCs33+sXN72dGuL4pbK+ifciLI14yqOGJogkCss2ZbdH3h8s6pcPR4qE8Zmwhz87M5M+t21V8+DJtj7QLt3hdBG+DIcYUykpR6SGk1lGagLJKNdzHGw5T1/W51WImMHHPXv12e1zZew="
+
+cache:
+  directories:
+  - $HOME/.m2


### PR DESCRIPTION

[Caching Dependencies and Directories](https://docs.travis-ci.com/user/caching/) Travis CI can cache content that does not often change, to speed up the build process.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
